### PR TITLE
add job to sync labels for defined repositories

### DIFF
--- a/.github/workflows/sync-org-labels.yml
+++ b/.github/workflows/sync-org-labels.yml
@@ -1,0 +1,99 @@
+name: Sync Org Labels
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/sync-labels.yaml
+      - labels.json
+      - repos.yaml
+  workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'  # At 01:00.
+
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install js-yaml
+        run: npm install js-yaml
+
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{secrets.PAT_GITHUB}}
+          script: |
+            var fs = require('fs');
+            const yaml = require('js-yaml');
+            // Read Repos to apply the labels
+            const repos = yaml.load(fs.readFileSync(`${process.env.GITHUB_WORKSPACE}/repos.yaml`, 'utf8'));
+
+            // Labels to apply
+            const labels = require(`${process.env.GITHUB_WORKSPACE}/labels.json`);
+
+            // Gets current labels available on repo
+            const currentLabels = repo =>
+              github.paginate(
+                github.rest.issues.listLabelsForRepo,
+                repo,
+                response => response.data.map(label => ({
+                  name: label.name,
+                  color: label.color,
+                  description: label.description
+                }))
+              );
+
+            // Syncs the config above with the target {owner, repo}
+            const syncLabels = async repo => {
+              const key = label => label.name.toLowerCase();
+
+              const existing = new Map();
+              (await currentLabels(repo)).forEach(label => existing.set(key(label), label));
+
+              const updates = labels.map(async label => {
+                try {
+                  let label_k = key(label);
+                  let current = existing.get(label_k);
+                  existing.delete(label_k);
+                  if (current == undefined) {
+                    if (current = existing.get(label.alias)) {
+                      core.info(`Renaming ${label.alias} to ${label.name}`);
+                      return await github.rest.issues.updateLabel({
+                        ...repo,
+                        name: label.alias,
+                        new_name: label.name,
+                        description: label.description,
+                        color: label.color
+                      });
+                    } else {
+                      core.info(`Creating ${label.name}`);
+                      return await github.rest.issues.createLabel({...repo, ...label});
+                    }
+                  } else if (current.color == label.color && current.description == label.description) {
+                    core.info(`Skipping ${label.name}`);
+                  } else {
+                    core.info(`Updating ${label.name}`);
+                    return await github.rest.issues.updateLabel({...repo, ...label});
+                  }
+                } catch (err) {
+                  core.error(`Error applying ${label.name}: ${err}`);
+                  throw err;
+                }
+              });
+
+              if (existing.size > 0) {
+                const orphaned = Array.from(existing.keys());
+                core.warning(`Additional labels exist on ${repo.repo}: ${orphaned.join(', ')}`);
+              }
+
+              return Promise.all(updates);
+            };
+
+            for (const repo of repos['repos']) {
+              await core.group(repo, () => syncLabels({
+                owner: context.repo.owner,
+                repo: repo
+              }).catch(core.setFailed));
+            };

--- a/README.md
+++ b/README.md
@@ -1,2 +1,24 @@
 # .github
 Default files to be used for any public repository under the chainguard-dev organization.
+
+This repository contains tooling and templates to assist in the management and daily work of the Chainguard-dev GitHub organisation.
+
+---
+
+# Labels
+
+The org labels are defined in `labels.json`, and the Repositories to the labels to be
+applied are defined in `repos.yaml`, please open a PR for any changes.
+
+Any changes will be applied to all repos via the [Sync Org Labels workflow](https://github.com/chainguard-dev/.github/workflows/sync-org-labels.yml).
+
+This only add new labels and update labels it does not remove labels that were created manually in a repository.
+
+When renaming a label, use the `alias` property to specify the old name. For example:
+
+```json
+{
+  "name": "type: bug",
+  "alias": "bug"
+}
+```

--- a/labels.json
+++ b/labels.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "test",
+    "description": null,
+    "color": "3e4b9e"
+  }
+]

--- a/repos.yaml
+++ b/repos.yaml
@@ -1,0 +1,5 @@
+# repos that the labels.json will be applied all the others will not be updated.
+---
+repos:
+  - apko
+  - melange


### PR DESCRIPTION
This define two files
- `labels.json` have all the label definition to be applied
- `repos.yaml` all the repositories in the chainguard-dev that the labels will be applied


this is the last org :) so

Fixes: https://github.com/chainguard-dev/internal/issues/933