### PR TITLE
Add a policy to allow our internal audit workflow access w/o PAT

### DIFF
--- a/.github/chainguard/github-audit-alerter.sts.yaml
+++ b/.github/chainguard/github-audit-alerter.sts.yaml
@@ -1,0 +1,16 @@
+# Copyright 2024 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/internal:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/internal/.github/workflows/github-audit-alerter.yaml@refs/heads/main
+
+# The permissions needed to run https://github.com/chainguard-dev/github-audit-alerter
+permissions:
+  administration: read
+  organization_administration: read
+  security_events: read
+
+# This operates across the entire organization.
+repositories: []


### PR DESCRIPTION
Echoing Thomas' comment on permissions here:

In terms of fine-grained tokens, the perms it needed were: Repository permissions: Administration: Read-only
Organization permissions: Administration: Read-only, Events: Read-only

I believe these fields roughly correlate to those fine-grained permissions.