### PR TITLE
fix: give enterprise gh updates write for issues

### DIFF
--- a/.github/chainguard/enterprise-github-updates.sts.yaml
+++ b/.github/chainguard/enterprise-github-updates.sts.yaml
@@ -5,6 +5,7 @@ claim_pattern:
 
 permissions:
   contents: write
+  issues: write
   pull_requests: write
   workflows: write
 


### PR DESCRIPTION
To fix problem encountered at: https://github.com/chainguard-dev/enterprise-packages/actions/runs/7686770627/job/20946010203#step:5:5279

I believe the update workflow needs to read open issues and also open new issues when there's a problem during the update.

cc: @mattmoor 