### PR TITLE
add missing permission

### DIFF
--- a/.github/chainguard/lifecycle-automation.sts.yaml
+++ b/.github/chainguard/lifecycle-automation.sts.yaml
@@ -8,6 +8,7 @@ subject_pattern: "(104827825967618219657|106649619308723948792)"
 permissions:
   pull_requests: write
   content: write
+  workflows: write
 
 # Allow for cloning, push, create prs
 repositories:


### PR DESCRIPTION
adding missing permission, that is required to when we are pushing commits, similar to the digestbot sts permissions and also to the PAT permission we have as well

forgot about this extra one