### PR TITLE
feat(octosts): Allow any client ID from the project for `appscript`

### DIFF
--- a/.github/chainguard/appscript.sts.yaml
+++ b/.github/chainguard/appscript.sts.yaml
@@ -3,8 +3,8 @@
 
 issuer: https://accounts.google.com
 subject_pattern: .*
-# The "Apps Script" client ID for the `philde-appscripts` project.
-audience: 292217359313-7vutdqjmljgk59a5vc3nkbj3i2sph52j.apps.googleusercontent.com
+# Allow client IDs from the `philde-appscripts` project.
+audience_pattern: 292217359313-[a-z0-9]+\.apps\.googleusercontent\.com
 claim_pattern:
   email_verified: "true"
   email: .*@chainguard.dev


### PR DESCRIPTION
Looks like AppScript creates a different ClientID for each different script. This grants access to any script connected with project number 292217359313