### PR TITLE
feat(octosts): Grant `contents` read to `appscript`

### DIFF
--- a/.github/chainguard/appscript.sts.yaml
+++ b/.github/chainguard/appscript.sts.yaml
@@ -10,8 +10,8 @@ claim_pattern:
   email: .*@chainguard.dev
 
 permissions:
-  issues: read
   contents: read
+  issues: read
   organization_projects: read
 
 repositories: [] # Act over all of the repos in the org.

--- a/.github/chainguard/appscript.sts.yaml
+++ b/.github/chainguard/appscript.sts.yaml
@@ -11,6 +11,7 @@ claim_pattern:
 
 permissions:
   issues: read
+  contents: read
   organization_projects: read
 
 repositories: [] # Act over all of the repos in the org.


### PR DESCRIPTION
The current token can read the project and return the list of fields. However, it can't list the content (items) of the project. Searching online suggests that `contents` is required.