### PR TITLE
init security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Thank you for taking the time to disclose a potential security issue responsibly.
+
+Please report vulnerabilities via email to [security@chainguard.dev](mailto:security@chainguard.dev). 
+
+To assist our triage, please include:
+- A clear description of the issue and its potential impact.
+- Steps to reproduce or proof-of-concept if available.
+- Affected versions or commit hashes.
+- Any known mitigations or fixes.
+- How you would like to be credited if attribution is desired (e.g., name, handle).
+
+## Disclosure Policy
+
+We are grateful when vulnerabilities are reported to us.
+
+As a reporter, you can expect:
+- A prompt acknowledgment of your report (within 72 hours).
+- A transparent dialog and timely fix for valid issues.
+- Credit for responsible disclosure, if desired.
+
+Please see the full [Chainguard Vulnerability Disclosure Policy](https://www.chainguard.dev/legal/inbound-vulnerability-disclosure-policy) to learn more.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-Thank you for taking the time to disclose a potential security issue responsibly.
+Thank you for taking the time to disclose a potential security issue.
 
 Please report vulnerabilities via email to [security@chainguard.dev](mailto:security@chainguard.dev). 
 
@@ -20,6 +20,6 @@ We are grateful when vulnerabilities are reported to us.
 As a reporter, you can expect:
 - A prompt acknowledgment of your report (within 72 hours).
 - A transparent dialog and timely fix for valid issues.
-- Credit for responsible disclosure, if desired.
+- Credit for disclosure, if desired.
 
 Please see the full [Chainguard Vulnerability Disclosure Policy](https://www.chainguard.dev/legal/inbound-vulnerability-disclosure-policy) to learn more.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ To assist our triage, please include:
 - Steps to reproduce or proof-of-concept if available.
 - Affected versions or commit hashes.
 - Any known mitigations or fixes.
-- How you would like to be credited if attribution is desired (e.g., name, handle).
+- How you would like to be credited if attribution is desired (e.g., name, known handle).
 
 ## Disclosure Policy
 


### PR DESCRIPTION
Sets a minimal security policy.

I do not love that security@chainguard.dev does not have a PGP key. We should have a better method of vulnerability reporting than cleartext. (It's _fine_ if the reporter's chosen medium is cleartext emails, but we should provide secure options.) An alternative would be to opt all repos into github private vulnerability reporting (PVR). Coordinating a vulnerability across multiple groups is vastly easier in a glorified GitHub issue than email.

I put emphasis into thanking the reporter and respecting the relationship with them. A positive relationship with the reporter is the most important aspect of coordinated vulnerability disclosure in my experience. We have no bug bounty, and the reporter is offering us free labor. Often these kinds of reporters truly care about resolving security issues. It would be great to have a public thank you page for valid reports. The credit I mention in this policy would at least go into CVE metadata.

This policy allows _inclusive identities_ or common names instead of requiring _real names_ https://github.com/canonical/ubuntu.com/pull/13233 https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=d4563201f33a022fc0353033d9dfeb1606a88330