### PR TITLE
WIP: define org-wide policy to read private repos

### DIFF
--- a/.github/chainguard/private-cg-repos.yaml
+++ b/.github/chainguard/private-cg-repos.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# This policy allows Chainguard employees to access private GitHub repositories
+# using `chainctl auth octo-sts`, in order to generate short-lived, tightly-scoped
+# GitHub access tokens when building packages locally.
+
+issuer: https://accounts.google.com
+claim_pattern:
+  email_verified: "true"
+  email: .*@chainguard.dev
+
+permissions:
+  contents: read
+
+repositories:
+- chainguard-dev/ecosystems-cassandra
+- chainguard-dev/ecosystems-kafka
+- chainguard-dev/iamguarded-tools


### PR DESCRIPTION
This allows `chainctl auth octo-sts --identity=<policy-name> --scope=chainguard-dev/ecosystems-cassandra` to generate a short-lived, tightly-scoped token to read that repo, if paired with any token issued by Google for a user whose verified email is `@chainguard.dev`.

Bikesheds:
- [ ] name of the file / policy -- currently `private-cg-repos` which is intentionally bad so you think of something better
- [ ] what other repos do we want?