### PR TITLE
guarded-package-repos.sts.yaml: add chainguard-dev/mono to accessible repos

### DIFF
--- a/.github/chainguard/guarded-package-repos.sts.yaml
+++ b/.github/chainguard/guarded-package-repos.sts.yaml
@@ -25,4 +25,5 @@ repositories:
   - iamguarded-charts
   - iamguarded-containers
   - iamguarded-tools
+  - mono
   - zulu-jdk21u


### PR DESCRIPTION
Commit b3075ce ("WIP: define org-wide policy to read private repos (#88)") (plus followup fixes) added support for limited scope tokens for pull access to private chainguard repos.

Unfortunately one repo used by the cg package was overlooked, chainguard-dev/mono. Add this repo.


Fixes: b3075ce ("WIP: define org-wide policy to read private repos (#88)")