### PR TITLE
add sync gh users to chainguard-devops

### DIFF
--- a/.github/chainguard/sync-gh-users.sts.yaml
+++ b/.github/chainguard/sync-gh-users.sts.yaml
@@ -1,0 +1,15 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/chainguard-devops:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/chainguard-devops/.github/workflows/copy-gh-users.yaml@refs/heads/main
+
+permissions:
+  contents: write # read/write file in chainguard-devops
+  pull_requests: write # create PR
+
+repositories:
+  - infra
+  - chainguard-devops


### PR DESCRIPTION
xref: https://github.com/chainguard-dev/chainguard-devops/pull/769