### PR TITLE
Add org-level OctoSTS policy for linear-syncer bot

### DIFF
--- a/.github/chainguard/linear_project_syncer.sts.yaml
+++ b/.github/chainguard/linear_project_syncer.sts.yaml
@@ -1,0 +1,15 @@
+issuer: https://accounts.google.com
+
+# POC bot for syncing GitHub project data
+# Running in jrawlings2-chainguard-dev project for evaluation purposes
+# Service account: 107440718730380529713
+subject: "107440718730380529713"
+
+permissions:
+  organization_projects: read
+  issues: read
+  pull_requests: read
+  metadata: read
+
+repositories:
+  - internal-dev


### PR DESCRIPTION
This policy enables a syncer bot to access GitHub organization-level projects and read issues from an internal repository. The bot needs org-level access to query GitHub Projects V2 which are organization resources.

Part of an evaluation POC to map GitHub project fields to other constructs.