### PR TITLE
Add a trust policy to test `staging-autofix`

### DIFF
--- a/.github/chainguard/staging-autofix.sts.yaml
+++ b/.github/chainguard/staging-autofix.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://accounts.google.com
+# autofix@staging-enforce-cd1e.iam.gserviceaccount.com
+subject: "118295070799166027529"
+
+permissions:
+  checks: read
+  contents: write
+  pull_requests: write
+  statuses: read
+  workflows: write # Allow triggering actions when authoring commits.
+
+repositories:
+  - terraform-infra-common


### PR DESCRIPTION
This will be scope to common infra for now.