### PR TITLE
Expand scope of `staging-autofix`

### DIFF
--- a/.github/chainguard/staging-autofix.sts.yaml
+++ b/.github/chainguard/staging-autofix.sts.yaml
@@ -10,4 +10,6 @@ permissions:
   workflows: write # Allow triggering actions when authoring commits.
 
 repositories:
+  - enterprise-packages
+  - mono
   - terraform-infra-common


### PR DESCRIPTION
This adds a couple more repos to the scope of what autofix can interact with in staging.