### PR TITLE
Enable mgreau's autofixer to get access to GH workflows logs

### DIFF
--- a/.github/chainguard/mgreau-autofix.sts.yaml
+++ b/.github/chainguard/mgreau-autofix.sts.yaml
@@ -3,6 +3,7 @@ issuer: https://accounts.google.com
 subject: "104658657678730945684"
 
 permissions:
+  actions: read
   checks: write
   contents: write
   pull_requests: read


### PR DESCRIPTION
Attempt to fix the following 403 issues i ([logs](https://console.cloud.google.com/logs/query;query=resource.type%3D%22cloud_run_revision%22%0Aresource.labels.service_name%3D~%22autofix%22%0AjsonPayload.key%3D%22https:%2F%2Fgithub.com%2Fchainguard-dev%2Fenterprise-packages%2Fpull%2F35230%22%0A;storageScope=project;summaryFields=:false:32:beginning;cursorTimestamp=2025-10-06T02:49:21.209985847Z;startTime=2025-10-06T02:42:00.000Z?project=mgreau85-chainguard))
```
- ERROR 2025-10-06T02:49:21.209927637Z Failed to set in-progress status
building output: marshaling status: json: error calling MarshalJSON for type *future.F[*chainguard.dev/agents/pkg/agents/loganalyzer.Analysis]: fetching logs for check run 52006663577: failed to get workflow job logs URL: unexpected status code: 403 Forbidden
- ERROR 2025-10-06T02:49:21.209965857Z Reconciliation failed for key https://github.com/chainguard-dev/enterprise-packages/pull/35230: building output: marshaling status: json: error calling MarshalJSON for type *future.F[*chainguard.dev/agents/pkg/agents/loganalyzer.Analysis]: fetching logs for check run 52006663577: failed to get workflow job logs URL: unexpected status code: 403 Forbidden
- ERROR 2025-10-06T02:49:21.209985847Z finished call
building output: marshaling status: json: error calling MarshalJSON for type *future.F[*chainguard.dev/agents/pkg/agents/loganalyzer.Analysis]: fetching logs for check run 52006663577: failed to get workflow job logs URL: unexpected status code: 403 Forbidden
```
