### PR TITLE
Add universal chainguard enforce commit signing config

### DIFF
--- a/.chainguard/source.yaml
+++ b/.chainguard/source.yaml
@@ -1,0 +1,19 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+spec:
+  authorities:
+    - keyless:
+        url: https://fulcio.sigstore.dev
+        identities:
+          # Humans
+          - issuer: https://github.com/login/oauth
+          # Humans and service accounts
+          - issuer: https://accounts.google.com
+          # Github actions
+          - issuer: https://token.actions.githubusercontent.com
+      ctlog:
+        url: https://rekor.sigstore.dev
+  # Any github verified
+  github:
+    verified: true


### PR DESCRIPTION
This adds a universal chianguard enforce commit signing config. This
supports all keyless and github verified signing methods, and covers
all humans and trusted robots.

Such config is universal, and will continue to work across repository
renames and moves.

If desired, the config can be locked down further but so far we
haven't managed to make enforce a required check but hopefully such
wide policy can actually be ratcheted to be made required as any and
all signing methods are supported and trusted.
