### PR TITLE
Update livegrep indexer STS policy to new service account

### DIFF
--- a/.github/chainguard/dev-jml-livegrep-indexer.sts.yaml
+++ b/.github/chainguard/dev-jml-livegrep-indexer.sts.yaml
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Octo STS policy for jml's livegrep indexer dev environment.
-# Service account: livegrep-indexer@jml-test-chainguard-dev.iam.gserviceaccount.com
+# Service account: livegrep@jml-chainguard-dev.iam.gserviceaccount.com
 
 issuer: https://accounts.google.com
-subject: "101068058788458667673"
+subject: "113476702918862144733"
 
 permissions:
   # Clone repository contents for code search indexing


### PR DESCRIPTION
## What

Update the `dev-jml-livegrep-indexer` Octo STS policy subject from the old service account (`livegrep-indexer@jml-test-chainguard-dev`) to the new one (`livegrep@jml-chainguard-dev`).

## Why

The livegrep deployment moved from the `jml-test-chainguard-dev` project to `jml-chainguard-dev` with a new Terraform module and service account. The old SA unique ID no longer matches the VM that runs the indexer.

## Notes

The new SA unique ID (`113476702918862144733`) comes from `terraform output service_account_unique_id` in `env/dev/jml/500-livegrep/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)