### PR TITLE
feat: add OctoSTS policy for cbutler manifest-gen dev environment

### DIFF
--- a/.github/chainguard/dev-cbutler-manifest-gen.sts.yaml
+++ b/.github/chainguard/dev-cbutler-manifest-gen.sts.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for manifest-gen dev environment
+# Service account: cbutler-mfg@cbutler-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "110753212323244908361"
+
+permissions:
+  # Read github actions logs
+  actions: read
+
+  # Read check status
+  checks: read
+
+  # Create and push branches
+  contents: write
+
+  # Create and update pull requests
+  pull_requests: write
+
+  # Read issues
+  issues: read
+
+  # Trigger and manage GitHub Actions workflows
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
Grants cbutler-mfg@cbutler-dev.iam.gserviceaccount.com access to chainguard-dev/stereo for manifest-gen development.