### PR TITLE
chore(sync-github): add new org scopes

### DIFF
--- a/.github/chainguard/sync-github.sts.yaml
+++ b/.github/chainguard/sync-github.sts.yaml
@@ -7,11 +7,12 @@ claim_pattern:
   job_workflow_ref: chainguard-dev/infra/.github/workflows/.terraform.yaml@.*
 
 permissions:
-  organization_administration: write # required to manage organization rulesets
   administration: write # required to manage the repository
   contents: write # required per terraform docs (https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository)
   members: write # to add/remove GitHub members
   metadata: read # to read metadata about the org
+  organization_administration: write # required to manage organization rulesets
+  organization_custom_org_roles: write # required for managing custom organization roles
+  organization_custom_roles: write # required for managing custom repository roles
   pages: write # to manage GitHub Pages as part of the repository management
-
 repositories: [] # Act over all of the repos in the org.

--- a/.github/chainguard/verify-github.sts.yaml
+++ b/.github/chainguard/verify-github.sts.yaml
@@ -7,11 +7,12 @@ claim_pattern:
   job_workflow_ref: chainguard-dev/infra/.github/workflows/.terraform.yaml@.*
 
 permissions:
-  organization_administration: write # required to read organization rulesets
   administration: read # required to read the repository
   contents: write # required per terraform docs (https://registry.terraform.io/providers/integrations/github/latest/docs/resources/repository)
   members: read # to read GitHub members information
   metadata: read # to read metadata about the org
+  organization_administration: write # required to read organization rulesets
+  organization_custom_org_roles: read # required for reading custom organization roles
+  organization_custom_roles: read # required for reading custom repository roles
   pages: read # to read GitHub Pages settings as part of the repository management
-
 repositories: [] # Act over all of the repos in the org.


### PR DESCRIPTION
This PR adds two new octo-sts scopes to manage roles via IAC.