### PR TITLE
add policies for images-private -(read)> mono

### DIFF
--- a/.github/chainguard/images-private-presubmit-build.sts.yaml
+++ b/.github/chainguard/images-private-presubmit-build.sts.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Read access to mono from images-private presubmit-build workflow.
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: repo:chainguard-images/images-private:.*
+claim_pattern:
+  workflow_ref: chainguard-images/images-private/.github/workflows/presubmit-build.yaml@refs/heads/main
+permissions:
+  contents: read
+
+repositories:
+  - mono

--- a/.github/chainguard/images-private-release.sts.yaml
+++ b/.github/chainguard/images-private-release.sts.yaml
@@ -1,13 +1,11 @@
 # Copyright 2026 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Read access to mono from images-private release and release-test workflows.
-# release-test.yaml is a reusable workflow called by release.yaml, so it has
-# its own workflow_ref OIDC claim.
+# Read access to mono from images-private release workflow.
 issuer: https://token.actions.githubusercontent.com
 subject: repo:chainguard-images/images-private:ref:refs/heads/main
 claim_pattern:
-  workflow_ref: chainguard-images/images-private/\.github/workflows/release(-test)?\.yaml@refs/heads/main
+  workflow_ref: chainguard-images/images-private/.github/workflows/release.yaml@refs/heads/main
 permissions:
   contents: read
 

--- a/.github/chainguard/images-private-release.sts.yaml
+++ b/.github/chainguard/images-private-release.sts.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Read access to mono from images-private release and release-test workflows.
+# release-test.yaml is a reusable workflow called by release.yaml, so it has
+# its own workflow_ref OIDC claim.
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-images/images-private:ref:refs/heads/main
+claim_pattern:
+  workflow_ref: chainguard-images/images-private/\.github/workflows/release(-test)?\.yaml@refs/heads/main
+permissions:
+  contents: read
+
+repositories:
+  - mono


### PR DESCRIPTION
add policies so that images-private CI (release.yaml and postsubmit) can clone mono