### PR TITLE
add policy for cuebump-pr to clone mono for `art`

### DIFF
--- a/.github/chainguard/images-private-cue-bump-pr.sts.yaml
+++ b/.github/chainguard/images-private-cue-bump-pr.sts.yaml
@@ -1,0 +1,13 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Read access to mono from images-private cue-bump-pr workflow.
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-images/images-private:ref:refs/heads/main
+claim_pattern:
+  workflow_ref: chainguard-images/images-private/.github/workflows/cue-bump-pr.yaml@refs/heads/main
+permissions:
+  contents: read
+
+repositories:
+  - mono


### PR DESCRIPTION
pre-req for https://github.com/chainguard-images/images-private/pull/180208