### PR TITLE
Add repository configuration (mono) for staging autofix

### DIFF
--- a/.github/chainguard/staging-autofix.sts.yaml
+++ b/.github/chainguard/staging-autofix.sts.yaml
@@ -9,3 +9,7 @@ permissions:
   pull_requests: write
   statuses: read
   workflows: write # Allow triggering actions when authoring commits.
+
+repositories:
+  - mono
+


### PR DESCRIPTION
We want to test autofix in staging against `mono` for o11y (braintrust) and RAG feature