### PR TITLE
sts: clean up eco-fixer-reconciler subject

### DIFF
--- a/.github/chainguard/eco-fixer-reconciler.sts.yaml
+++ b/.github/chainguard/eco-fixer-reconciler.sts.yaml
@@ -1,13 +1,12 @@
 issuer: https://accounts.google.com
 # fixer-reconciler@prod-enforce-fabc.iam.gserviceaccount.com (116479062745632404635)
 # fixer-reconciler@staging-enforce-cd1e.iam.gserviceaccount.com (102228530143871324400)
-# fixer-reconciler@dev-eco-jb8z.iam.gserviceaccount.com (110961938846974608911)
-subject_pattern: "(110961938846974608911|116479062745632404635|102228530143871324400)"
+subject_pattern: "(116479062745632404635|102228530143871324400)"
 
 permissions:
   checks: read
-  contents: read 
-  pull_requests: read 
+  contents: read
+  pull_requests: read
 
 repositories:
 - ecosystems-packages


### PR DESCRIPTION
- Removes stale `dev-eco-jb8z` SA (`110961938846974608911`); dev env uses identity `fixer-pr-reconciler`, not `eco-fixer-reconciler`
- Fixes trailing whitespace in permission values
- Linear: https://linear.app/chainguard/issue/DEV-1123