### PR TITLE
prod-eco: add SA id for staging-enforce

### DIFF
--- a/.github/chainguard/eco-fixer-reconciler.sts.yaml
+++ b/.github/chainguard/eco-fixer-reconciler.sts.yaml
@@ -1,8 +1,8 @@
 issuer: https://accounts.google.com
 # eco-fixer-reconciler@prod-enforce-fabc.iam.gserviceaccount.com (102687350045478824621)
-# eco-fixer-reconciler@staging-enforce-cd1e.iam.gserviceaccount.com ()
+# eco-fixer-reconciler@staging-enforce-cd1e.iam.gserviceaccount.com (102481558459119149955)
 # eco-fixer-reconciler@dev-eco-jb8z.iam.gserviceaccount.com (107649951963973435701)
-subject_pattern: "(102687350045478824621|107649951963973435701)"
+subject_pattern: "(102687350045478824621|102481558459119149955|107649951963973435701)"
 
 permissions:
   checks: read


### PR DESCRIPTION
We were missing the SA id for the service running on staging.