### PR TITLE
chore: add octoSTS policy for arthur exaltacao project

### DIFF
--- a/.github/chainguard/dev-aexal15-manifest-gen.sts.yaml
+++ b/.github/chainguard/dev-aexal15-manifest-gen.sts.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for manifest-gen dev environment
+# Service account: projects/aexal15-dev/serviceAccounts/aexal15-mfg@aexal15-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+
+subject: "105399363622209499999"
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  pull_requests: write
+  issues: read
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION

This is so my deployment of the manifetst-gen bot has permissions to look at stereo

Grants my service account permissions to act on stereo
