### PR TITLE
chore(octo-sts): add trust policy for dev use

### DIFF
--- a/.github/chainguard/dev-egibs-agent.yaml
+++ b/.github/chainguard/dev-egibs-agent.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for egibs' dev agent environment.
+# Used by sandboxed Claude Code agents for read-only repo access.
+#
+# Service account: dev-agent@egibs-chainguard.iam.gserviceaccount.com
+# Subject ID: 102858891247966853136
+
+issuer: https://accounts.google.com
+subject: "102858891247966853136"
+
+permissions:
+  contents: read
+  pull_requests: read
+  issues: read
+  actions: read
+
+repositories: []


### PR DESCRIPTION
Reference: https://github.com/chainguard-dev/.github/blob/main/.github/chainguard/dev-eslerm-agent.sts.yaml