### PR TITLE
chore: add octo-sts policy for manifest-gen

### DIFF
--- a/.github/chainguard/dev-wimpress-manifest-gen.sts.yaml
+++ b/.github/chainguard/dev-wimpress-manifest-gen.sts.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for manifest-gen dev environment
+# Service account: projects/wimpress-dev/serviceAccounts/wimpress-mfg@wimpress-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+
+subject: "106382507195733163142"
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  pull_requests: write
+  issues: read
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
Adds an OctoSTS trust policy for the manifest-gen dev environment running under GCP project `wimpress-dev`.