### PR TITLE
chore: add octo-sts policy for chaindag livegrep indexer

### DIFF
--- a/.github/chainguard/chaindag-livegrep-indexer.sts.yaml
+++ b/.github/chainguard/chaindag-livegrep-indexer.sts.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the livegrep.chaindag.dev indexer.
+# Service account: livegrep@chaindag.iam.gserviceaccount.com
+# Deployed by: env/chaindag.dev/iac/livegrep.tf in chainguard-dev/mono
+
+issuer: https://accounts.google.com
+subject: "106681300217655979572"
+
+permissions:
+  # Clone repository contents for code search indexing
+  contents: read
+  # Required baseline permission for all GitHub API access
+  metadata: read


### PR DESCRIPTION
## What

Add \`chaindag-livegrep-indexer.sts.yaml\` granting \`contents:read\` + \`metadata:read\` across the \`chainguard-dev\` org to the chaindag livegrep indexer's GCP service account.

## Why

\`livegrep.chaindag.dev\` is the new production internal regex code-search deployment, replacing \`livegrep.jml.guardenv.dev\`. The indexer runs every 6 hours on a GCE VM in the \`chaindag\` GCP project, exchanges its GCP OIDC token via Octo STS for a GitHub token, then lists + clones all repos in \`chainguard-dev\` to build the search index. Without this policy the indexer can't authenticate and the index stays empty.

Mirrors the existing \`dev-jml-livegrep-indexer.sts.yaml\` policy (same permissions, different subject) — that one is for the personal dev deployment and will be retired once chaindag is stable.

## Notes

- Subject \`106681300217655979572\` is the unique ID of \`livegrep@chaindag.iam.gserviceaccount.com\`, deployed by chainguard-dev/mono at \`env/chaindag.dev/iac/livegrep.tf\` (\`sts_policy = "chaindag-livegrep-indexer"\`).
- Permissions are read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)