### PR TITLE
feat(octosts): add dev-mrisharma-image-gen SA policy

### DIFF
--- a/.github/chainguard/dev-mrisharma-image-gen.sts.yaml
+++ b/.github/chainguard/dev-mrisharma-image-gen.sts.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for image-gen dev environment
+# Service account: mrisharma-img@mrisharma-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "116882447240315381299"
+
+permissions:
+  # Read github actions logs
+  actions: read
+
+  # Read check status
+  checks: read
+
+  # Create and push branches with the generated image package
+  contents: write
+
+  # Create and update pull requests
+  pull_requests: write
+
+  # Read issues (the bot's trigger)
+  issues: read
+
+  # Trigger and manage GitHub Actions workflows
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
Authorizes mrisharma-img@mrisharma-dev.iam.gserviceaccount.com (unique_id 116882447240315381299) to act on chainguard-dev/stereo via Octo STS for the image-gen dev bot. Mirrors dev-mrisharma-manifest-gen

For more ref https://github.com/chainguard-dev/mono/pull/40051