### PR TITLE
add write access to staging-manifest-gen

### DIFF
--- a/.github/chainguard/staging-manifest-gen.sts.yaml
+++ b/.github/chainguard/staging-manifest-gen.sts.yaml
@@ -21,7 +21,7 @@ permissions:
   pull_requests: write
 
   # Read issues
-  issues: read
+  issues: write
 
   # Trigger and manage GitHub Actions workflows
   workflows: write


### PR DESCRIPTION
bot needs write permissions on issues to decline issues that request packages that should not be built. see https://github.com/chainguard-dev/mono/pull/39511