### PR TITLE
feat(octosts): add dev-sbeattie-agent SA policy

### DIFF
--- a/.github/chainguard/dev-sbeattie-agent.sts.yaml
+++ b/.github/chainguard/dev-sbeattie-agent.sts.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for sbeattie's dev agent environment.
+# Used by sandboxed Claude Code agents for read-only repo access.
+#
+# Service account: dev-agent@sbeattie-dev.iam.gserviceaccount.com
+# Subject ID: 107257230342533501395
+
+issuer: https://accounts.google.com
+subject: "107257230342533501395"
+
+permissions:
+  contents: read
+  pull_requests: read
+  issues: read
+  actions: read
+
+repositories: []


### PR DESCRIPTION
## Summary
- Adds OctoSTS trust policy for sbeattie's dev environment agent service account
- Subject: `107257230342533501395` (SA `dev-agent@sbeattie-dev.iam.gserviceaccount.com`)
- Read-only across all chainguard-dev repos (`contents`, `pull_requests`, `issues`, `actions`)
- Matches the pattern set by `dev-egibs-agent.sts.yaml` and `dev-eslerm-agent.sts.yaml`

Used by sandboxed Claude Code agents (e.g., `claude-guard`) for read-only repo access.

## Test plan
- [ ] After merge: `chainctl auth login` flow + `claude-guard run --pr chainguard-dev/mono#<n>` succeeds in minting an OctoSTS token via this policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)