### PR TITLE
add octosts policy for mcp-slack-bot to read PRs in stereo

### DIFF
--- a/.github/chainguard/mcp-slack-bot.sts.yaml
+++ b/.github/chainguard/mcp-slack-bot.sts.yaml
@@ -1,0 +1,12 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+issuer: https://accounts.google.com
+# mcp-slack-bot-worker@staging-enforce-cd1e.iam.gserviceaccount.com
+subject: "116448882333472298588"
+
+permissions:
+  pull_requests: read
+
+repositories:
+- stereo


### PR DESCRIPTION
## Summary

- Adds an OctoSTS policy allowing the `mcp-slack-bot` staging worker to read pull requests in `chainguard-dev/stereo`
- SA: `mcp-slack-bot-worker@staging-enforce-cd1e.iam.gserviceaccount.com`
- Needed to teach the bot to surface stuck version-stream PRs