### PR TITLE
Add STS policy for confidence bot in jbcg dev env

### DIFF
--- a/.github/chainguard/dev-joedborg-confidence.sts.yaml
+++ b/.github/chainguard/dev-joedborg-confidence.sts.yaml
@@ -1,0 +1,14 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for confidence bot in Joe Borg's dev environment.
+# Service account: confidence@borg-chainguard-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "118047872954112399052"
+
+permissions:
+  contents: read
+  pull_requests: read
+  issues: write
+  checks: read


### PR DESCRIPTION
To test https://github.com/chainguard-dev/mono/pull/39607 in dev env