### PR TITLE
feat(octosts): add dev-zkranurag-image-gen SA policy

### DIFF
--- a/.github/chainguard/dev-zkranurag-image-gen.sts.yaml
+++ b/.github/chainguard/dev-zkranurag-image-gen.sts.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for image-gen dev environment
+# Service account: zkranurag-img@zkranurag-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "111184961842370500608"
+
+permissions:
+  # Read github actions logs
+  actions: read
+
+  # Read check status
+  checks: read
+
+  # Create and push branches with the generated image package
+  contents: write
+
+  # Create and update pull requests
+  pull_requests: write
+
+  # Read issues (the bot's trigger)
+  issues: read
+
+  # Trigger and manage GitHub Actions workflows
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
## Summary

- Adds OctoSTS trust policy for `zkranurag-img@zkranurag-dev.iam.gserviceaccount.com`
- The `zkranurag-img-rec` Cloud Run service uses `OCTO_IDENTITY=dev-zkranurag-image-gen` to push branches/PRs to `chainguard-dev/stereo`
- Missing policy was causing ~300k failed OctoSTS calls/day since 2026-05-14 (~995k total errors in 7 days)
- Modelled on the existing `dev-mrisharma-image-gen.sts.yaml` (same permissions, same target repo)

## Permissions

Same as `dev-mrisharma-image-gen.sts.yaml`: actions/checks read, contents/pull_requests/workflows write, scoped to `stereo` only.