### PR TITLE
fix(confidence): use pull_requests:write, not issues:write

### DIFF
--- a/.github/chainguard/staging-confidence.sts.yaml
+++ b/.github/chainguard/staging-confidence.sts.yaml
@@ -9,7 +9,6 @@ subject: "115043002511973758160"
 
 permissions:
   contents: read
-  pull_requests: read
+  pull_requests: write
   statuses: read
-  issues: write
   checks: read


### PR DESCRIPTION
The staging confidence bot operates on PRs (labels + comments via the `gh.Issues.*` methods that share REST endpoints with real issues). GitHub's App permission model treats PRs and issues as separate scopes — "Issue permissions only apply to issues, not pull requests" — so `issues: write` yields `403 Resource not accessible by integration` on PRs.

Matches the pattern used by `approver-bot` / `manifest-gen` / `skillup` which all label and comment on PRs successfully with `pull_requests: write`.

## Symptom

In staging since 2026-05-27 ~14:00 UTC (post #40991 going live), every label-apply and comment-post attempt has returned 403 — 38+/hr. Reads work fine (`PullRequests.Get`, `Checks.ListCheckRunsForRef` etc.) because `pull_requests: read` was correct.

## Fix

```diff
 permissions:
   contents: read
-  pull_requests: read
+  pull_requests: write
   statuses: read
-  issues: write
   checks: read
```

`issues: write` is dropped — confidence never operates on real issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)