### PR TITLE
feat(confidence-sts): grant administration:read

### DIFF
--- a/.github/chainguard/staging-confidence.sts.yaml
+++ b/.github/chainguard/staging-confidence.sts.yaml
@@ -12,3 +12,4 @@ permissions:
   pull_requests: write
   statuses: read
   checks: read
+  administration: read # Read the base branch's required status checks for the CI gate


### PR DESCRIPTION
Adds `administration: read` to this identity so it can read branch protection settings (required status checks). Read-only.