### PR TITLE
mcp-slack-bot: grant read access to image-release-stats chonk issues

### DIFF
--- a/.github/chainguard/mcp-slack-bot.sts.yaml
+++ b/.github/chainguard/mcp-slack-bot.sts.yaml
@@ -6,7 +6,12 @@ issuer: https://accounts.google.com
 subject: "116448882333472298588"
 
 permissions:
+  issues: read
   pull_requests: read
 
 repositories:
+# stereo: read pull requests (skillup PRs, build status).
 - stereo
+# image-release-stats: read chonk issues to check whether an image is a known
+# broken build before reporting on its health.
+- image-release-stats


### PR DESCRIPTION
Extends the `mcp-slack-bot` octo-sts trust policy so the bot can read issues in `chainguard-dev/image-release-stats`, adding `issues: read` and listing `image-release-stats` alongside `stereo`.

The bot previously declared an image "healthy" without consulting the chonk list, and was called out for it by the sustaining team. Chonks are tracked as GitHub issues in `image-release-stats`, so the bot needs read access to that repo before it can check whether an image is a known broken build prior to reporting on its health. This grant is the prerequisite for wiring the chonk check into the bot itself.