### PR TITLE
feat(octo-sts): grant guarded-package-repos read access to stereo

### DIFF
--- a/.github/chainguard/guarded-package-repos.sts.yaml
+++ b/.github/chainguard/guarded-package-repos.sts.yaml
@@ -25,4 +25,5 @@ repositories:
   - iamguarded-containers
   - iamguarded-tools
   - mono
+  - stereo
   - zulu-jdk


### PR DESCRIPTION
## What

Add `stereo` to the `repositories` list for the `guarded-package-repos` octo-sts identity.

## Why

`chart-iamguarded-*`'s chart source are being moved into `chainguard-dev/stereo`. Local builds in stereo auto-mint a `guarded-package-repos` octo-sts token (`chainctl auth octo-sts --identity=guarded-package-repos --scope=chainguard-dev`) to clone chart sources via the `auth/github` melange pipeline. That identity could read the iamguarded repos but not `stereo`, so `make package/chart-iamguarded-common` failed to clone its source. This grants the missing read access.