### PR TITLE
manifest-gen: grant prod octo-sts issues: write for comment/label reporting

### DIFF
--- a/.github/chainguard/prod-manifest-gen.sts.yaml
+++ b/.github/chainguard/prod-manifest-gen.sts.yaml
@@ -20,8 +20,8 @@ permissions:
   # Create and update pull requests
   pull_requests: write
 
-  # Read issues
-  issues: read
+  # Comment on and label issues
+  issues: write
 
   # Trigger and manage GitHub Actions workflows
   workflows: write


### PR DESCRIPTION
need this so that we can apply labels in case a package exists