### PR TITLE
feat(octosts): add lens-orchestrator + lens-lookout trust policies

### DIFF
--- a/.github/chainguard/lens-lookout.sts.yaml
+++ b/.github/chainguard/lens-lookout.sts.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the lens-lookout bot (dev environments).
+# Read-only watcher: it reads PR merge/mergeable state to detect drift and
+# heals via re-enqueue / Linear comments — it does NOT write to GitHub.
+# Mints GitHub tokens via octo-sts (OCTO_IDENTITY=lens-lookout).
+#
+# Authorized GCP service accounts (one per dev env), by numeric uniqueId:
+#   - lens-lookout@jrawlings2-chainguard-dev  (created on 410-lens-lookout apply)
+#   - lens-lookout@tbloom129-dev              (if/when deployed)
+#
+# TODO(post-apply): replace the PLACEHOLDER below with the uniqueIds, e.g.
+#   subject_pattern: "^(<jrawlings2-dev-sa-id>|<tbloom129-dev-sa-id>)$"
+issuer: https://accounts.google.com
+subject_pattern: "^PLACEHOLDER_REPLACE_WITH_DEV_SA_UNIQUE_IDS$"
+
+permissions:
+  # Read PR merge/mergeable state to detect drift.
+  contents: read
+  pull_requests: read
+
+repositories:
+  # TODO: scope to the repo(s) whose PRs the lookout inspects.
+  - PLACEHOLDER_TARGET_REPO

--- a/.github/chainguard/lens-orchestrator.sts.yaml
+++ b/.github/chainguard/lens-orchestrator.sts.yaml
@@ -1,0 +1,32 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the lens-orchestrator bot (dev environments).
+# The bot scaffolds projects and opens/updates pull requests, minting GitHub
+# tokens via octo-sts (OCTO_IDENTITY=lens-orchestrator).
+#
+# Authorized GCP service accounts (one per dev env), by numeric uniqueId:
+#   - lens-orchestrator@jrawlings2-chainguard-dev  (uniqueId 100436891842070281075)
+#   - lens-orchestrator@tbloom129-dev              (created on tbloom.dev apply)
+#
+# TODO(post-apply): replace the PLACEHOLDER below with both uniqueIds, e.g.
+#   subject_pattern: "^(100436891842070281075|<tbloom129-dev-sa-id>)$"
+issuer: https://accounts.google.com
+subject_pattern: "^PLACEHOLDER_REPLACE_WITH_DEV_SA_UNIQUE_IDS$"
+
+permissions:
+  # Read GitHub Actions logs for build/log feedback.
+  actions: read
+
+  # Read CI check status for reconcile gates.
+  checks: read
+
+  # Create and push scaffolding branches.
+  contents: write
+
+  # Create and update pull requests.
+  pull_requests: write
+
+repositories:
+  # TODO: scope to the repo(s) the dev orchestrator scaffolds into.
+  - PLACEHOLDER_TARGET_REPO


### PR DESCRIPTION
## Summary
Adds octo-sts trust policies for two dev bots so the `octosts-lint` check on the mono PRs passes:
- **lens-orchestrator** — scaffolds projects, opens/updates PRs (contents/pull_requests: write).
- **lens-lookout** — read-only drift watcher (reads PR merge state; pull_requests/contents: read).

Unblocks the "Verify trust policies exist for new OctoSTS identities" check on:
- chainguard-dev/mono#42519 (lens-orchestrator)
- chainguard-dev/mono#42524 (lens-lookout)

## ⚠️ Placeholders to fill post-apply
Per @rawlingsj — the `subject_pattern`s are **placeholders**; replace with the GCP SA `uniqueId`s once the dev-env GSAs are created on `terraform apply`:
- `lens-orchestrator@jrawlings2-chainguard-dev` = `100436891842070281075` (already exists)
- `lens-orchestrator@tbloom129-dev` — created on tbloom.dev apply
- `lens-lookout@jrawlings2-chainguard-dev` — created on 410-lens-lookout apply
- `lens-lookout@tbloom129-dev` — if/when deployed

The `repositories:` scope is also a placeholder pending confirmation of the bots' target repo(s).
