### PR TITLE
Add stereo issue write permissions for staging manifest-gen

### DIFF
--- a/.github/chainguard/staging-manifest-gen.sts.yaml
+++ b/.github/chainguard/staging-manifest-gen.sts.yaml
@@ -20,7 +20,7 @@ permissions:
   # Create and update pull requests
   pull_requests: write
 
-  # Read issues
+  # Read issues to fetch issue body; post failure comments and apply the halt label on issues
   issues: write
 
   # Trigger and manage GitHub Actions workflows


### PR DESCRIPTION
This allows manifest-gen to apply `skip:staging-manifest-gen` labels to issues to halt reconciling.

Example here: https://github.com/chainguard-dev/stereo/issues/110661