### PR TITLE
Grant confidence bot checks:write to publish grade check runs

### DIFF
--- a/.github/chainguard/confidence.sts.yaml
+++ b/.github/chainguard/confidence.sts.yaml
@@ -11,5 +11,5 @@ permissions:
   contents: read
   pull_requests: write
   statuses: read
-  checks: read
+  checks: write # Publish the grade as a check run on the PR head commit
   administration: read # Read the base branch's required status checks for the CI gate


### PR DESCRIPTION
The confidence bot will publish its grade as a check run on the PR head commit, binding the grade to a specific commit for the auto-merge gate. Creating a check run requires `checks: write`.

Bot change: chainguard-dev/mono#42871 (default-off until this lands).