### PR TITLE
feat(octosts): add staging-manifest-gen-improve trust policy (FUL-332)

### DIFF
--- a/.github/chainguard/staging-manifest-gen-improve.sts.yaml
+++ b/.github/chainguard/staging-manifest-gen-improve.sts.yaml
@@ -1,0 +1,26 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the manifest-gen-improve nightly pipeline, staging.
+# Service account: manifest-gen-improve@staging-enforce-cd1e.iam.gserviceaccount.com
+#
+# Read-only: the nightly stats->diagnose pipeline only reads manifest-gen PRs,
+# CI check-run statuses, and CI job logs to build failure reports. It never
+# writes. Mirrors the staging-manifest-gen writer sibling, scoped to stereo via
+# the repositories field.
+
+issuer: https://accounts.google.com
+subject: "102958354716030199789"
+
+permissions:
+  # Read CI job logs for failure analysis
+  actions: read
+
+  # Read CI check-run statuses
+  checks: read
+
+  # List and read manifest-gen PRs
+  pull_requests: read
+
+repositories:
+  - stereo


### PR DESCRIPTION
## Summary

Org-scoped, **read-only** OctoSTS trust policy so the manifest-gen-improve nightly pipeline (staging Cloud Run Job) can read from stereo to build failure reports. Linear: https://linear.app/chainguard/issue/FUL-332.

```yaml
issuer: https://accounts.google.com
# manifest-gen-improve@staging-enforce-cd1e.iam.gserviceaccount.com
subject: "102958354716030199789"
permissions:
  actions: read         # CI job logs for failure analysis
  checks: read          # CI check-run statuses
  pull_requests: read   # list/read manifest-gen PRs
repositories:
  - stereo
```

Mirrors the `staging-manifest-gen` writer sibling in this repo (same issuer, same `repositories: [stereo]` scoping), but read-only — the nightly `stats → diagnose` pipeline never writes. Subject is the runtime SA's numeric unique ID (`gcloud`-verified). Org scope matches `manifest-gen`'s `OrgMain` checkout of stereo.

## Why this is needed now

Hard prerequisite for chainguard-dev/mono#42820 (the nightly Cloud Run Job + scheduler). That PR's `Verify trust policies exist for new OctoSTS identities` gate resolves this identity to the **org** scope and stays red until this policy is on \`main\`; the cron there ships **paused** until it's verified live.

(Supersedes an earlier misplaced copy in `chainguard-dev/stereo`, now being reverted — that was repo-scoped and dead once the bot moved to org scope.)

## Test plan

- [ ] OctoSTS Trust Policy Validation passes
- [ ] After merge: mono#42820's OctoSTS-trust gate goes green, then first manual run from the mono side