### PR TITLE
feat(octosts): add prod-manifest-gen-improve trust policy (FUL-373)

### DIFF
--- a/.github/chainguard/prod-manifest-gen-improve.sts.yaml
+++ b/.github/chainguard/prod-manifest-gen-improve.sts.yaml
@@ -1,0 +1,33 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the manifest-gen-improve nightly pipeline, production.
+# Service account: manifest-gen-improve@prod-enforce-fabc.iam.gserviceaccount.com
+#
+# Read-only: the nightly stats->diagnose pipeline only reads manifest-gen PRs,
+# CI check-run statuses, and CI job logs to build failure reports. It never
+# writes. Mirrors staging-manifest-gen-improve, scoped to stereo via the
+# repositories field.
+#
+# TODO(FUL-373): replace subject: with the prod SA's Google numeric unique_id
+# once env/enforce.dev/iac/400-manifest-gen-improve has been applied (mono
+# #43326). Capture it from the stage's terraform output:
+#   terraform -chdir=env/enforce.dev/iac/400-manifest-gen-improve output service_account_unique_id
+# The placeholder below cannot match any real subject claim, so the policy is
+# inert until updated.
+
+issuer: https://accounts.google.com
+subject: "REPLACE_WITH_PROD_SA_UNIQUE_ID"
+
+permissions:
+  # Read CI job logs for failure analysis
+  actions: read
+
+  # Read CI check-run statuses
+  checks: read
+
+  # List and read manifest-gen PRs
+  pull_requests: read
+
+repositories:
+  - stereo

--- a/.github/chainguard/prod-manifest-gen-improve.sts.yaml
+++ b/.github/chainguard/prod-manifest-gen-improve.sts.yaml
@@ -8,16 +8,9 @@
 # CI check-run statuses, and CI job logs to build failure reports. It never
 # writes. Mirrors staging-manifest-gen-improve, scoped to stereo via the
 # repositories field.
-#
-# TODO(FUL-373): replace subject: with the prod SA's Google numeric unique_id
-# once env/enforce.dev/iac/400-manifest-gen-improve has been applied (mono
-# #43326). Capture it from the stage's terraform output:
-#   terraform -chdir=env/enforce.dev/iac/400-manifest-gen-improve output service_account_unique_id
-# The placeholder below cannot match any real subject claim, so the policy is
-# inert until updated.
 
 issuer: https://accounts.google.com
-subject: "REPLACE_WITH_PROD_SA_UNIQUE_ID"
+subject: "103853218931345145716"
 
 permissions:
   # Read CI job logs for failure analysis


### PR DESCRIPTION
## Summary

Mirrors `staging-manifest-gen-improve` for production. Read-only policy (`actions:read`, `checks:read`, `pull_requests:read`), scoped to `stereo`, for the nightly manifest-gen-improve pipeline running in `prod-enforce-fabc`.

## Status — ready to land

**Subject is the real SA `unique_id`** (`103853218931345145716`), captured from `terraform output service_account_unique_id` after the prod stage applied via the postsubmit on mono#43326. The earlier placeholder is gone; this PR is active-ready.

## Why two commits

The first commit (`a1d20c7`) staged the file with a placeholder subject so mono#43326's OctoSTS lint could see the policy on `chainguard-dev/.github` main. The lint only checks file existence, not subject correctness, so the placeholder unblocked the chain.

The second commit (`128711d`) sets the real subject now that the SA exists.

## What lands after merge

1. Merge this PR → OctoSTS policy active.
2. Manual `gcloud run jobs execute manifest-gen-improve-nightly --region us-central1 --project prod-enforce-fabc` → confirm OctoSTS auth, GitHub fetch, BQ write end-to-end.
3. Follow-up mono PR flips `cron_paused = false` and `staleness_alert_enabled = true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)