### PR TITLE
Add reviewbot octo-sts trust policies

### DIFF
--- a/.github/chainguard/dev-jrawlings-reviewbot.sts.yaml
+++ b/.github/chainguard/dev-jrawlings-reviewbot.sts.yaml
@@ -1,0 +1,14 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the reviewbot jrawlings2 dev environment.
+# Service account: reviewbot@jrawlings2-chainguard-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "110094049238630534449"
+
+permissions:
+  contents: read
+  pull_requests: write
+  checks: write
+  actions: read

--- a/.github/chainguard/staging-reviewbot.sts.yaml
+++ b/.github/chainguard/staging-reviewbot.sts.yaml
@@ -1,0 +1,15 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the reviewbot staging environment.
+# Service account: reviewbot@staging-enforce-cd1e.iam.gserviceaccount.com
+# Subject is the service account uniqueId; placeholder until provisioned.
+
+issuer: https://accounts.google.com
+subject: "REPLACE_WITH_STAGING_REVIEWBOT_SA_UNIQUE_ID"
+
+permissions:
+  contents: read
+  pull_requests: write
+  checks: write
+  actions: read


### PR DESCRIPTION
Adds Octo STS trust policies for the reviewbot service-account identities (staging and jrawlings2 dev) so they can mint org-scoped GitHub tokens.

Both are scoped to: `contents: read`, `pull_requests: write`, `checks: write`, `actions: read`.

The staging subject is a placeholder until the service account is provisioned.
