### PR TITLE
feat(octosts): add staging-image-gen trust policy (FUL-393)

### DIFF
--- a/.github/chainguard/staging-image-gen.sts.yaml
+++ b/.github/chainguard/staging-image-gen.sts.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for image-gen staging environment
+# Service account: image-gen@staging-enforce-cd1e.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "117648652703556190970"
+
+permissions:
+  # Read github actions logs
+  actions: read
+
+  # Read check status
+  checks: read
+
+  # Create and push branches with the generated image package
+  contents: write
+
+  # Create and update pull requests
+  pull_requests: write
+
+  # Read issues (the bot's trigger)
+  issues: read
+
+  # Trigger and manage GitHub Actions workflows
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
Adds the OctoSTS trust policy for the image-gen bot's staging deployment, mirroring `staging-manifest-gen.sts.yaml` and the dev image-gen policy (`issues: read`, least-privilege — image-gen only reads its trigger issue).

Service account: `image-gen@staging-enforce-cd1e.iam.gserviceaccount.com` (subject `117648652703556190970`, from the 400-image-gen terraform output).

Unblocks the "Verify trust policies exist for new OctoSTS identities" check on chainguard-dev/mono#43683 ([FUL-393](https://linear.app/chainguard/issue/FUL-393)).