### PR TITLE
chore(sts): Add issue write to cbutler-mfg

### DIFF
--- a/.github/chainguard/dev-cbutler-manifest-gen.sts.yaml
+++ b/.github/chainguard/dev-cbutler-manifest-gen.sts.yaml
@@ -20,8 +20,8 @@ permissions:
   # Create and update pull requests
   pull_requests: write
 
-  # Read issues
-  issues: read
+  # Read issues to fetch issue body; post failure comments and apply the halt label on issues
+  issues: write
 
   # Trigger and manage GitHub Actions workflows
   workflows: write


### PR DESCRIPTION
Update the STS bindings to allow the dev bot to write to stereo issues when the bot is blocked. Required for head of manifest-gen dev