### PR TITLE
feat(mcp-slack-bot): grant issues:write and add mono repo

### DIFF
--- a/.github/chainguard/mcp-slack-bot.sts.yaml
+++ b/.github/chainguard/mcp-slack-bot.sts.yaml
@@ -6,7 +6,7 @@ issuer: https://accounts.google.com
 subject: "116448882333472298588"
 
 permissions:
-  issues: read
+  issues: write          # was: read
   pull_requests: read
 
 repositories:
@@ -15,3 +15,4 @@ repositories:
 # image-release-stats: read chonk issues to check whether an image is a known
 # broken build before reporting on its health.
 - image-release-stats
+- mono

--- a/.github/chainguard/mcp-slack-bot.sts.yaml
+++ b/.github/chainguard/mcp-slack-bot.sts.yaml
@@ -6,7 +6,7 @@ issuer: https://accounts.google.com
 subject: "116448882333472298588"
 
 permissions:
-  issues: write          # was: read
+  issues: write          # write permission to create materializer issues from the slack bot
   pull_requests: read
 
 repositories:


### PR DESCRIPTION
REF AUTO-658

we want to be able to create github issues for the materializer to pick up.
With this change, we are granting mcp-slack-bot permission to write issue and adding mono repo to the list of repos it can create/read issues from.