### PR TITLE
feat(octo-sts): org-level lens-review-queue policy for multi-repo PR reads

### DIFF
--- a/.github/chainguard/lens-review-queue.sts.yaml
+++ b/.github/chainguard/lens-review-queue.sts.yaml
@@ -1,0 +1,23 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the Lens hub (LensReviewQueue data layer), org-scoped.
+# The hub mints a short-lived, read-only GitHub token to read pending review
+# requests on open PRs across the org, then flattens them for the
+# /api/review-queue/* endpoints. Org-scoped (repositories: []) so repos can be
+# added to the dashboard's REVIEW_QUEUE_REPOS env list without a policy change.
+#
+# Federates both hub Cloud Run service accounts by their Google numeric uniqueId:
+#   preview: linear-dashboard-sa@jrawlings2-chainguard-dev.iam.gserviceaccount.com
+#            uniqueId 106033804611612894562
+#   prod:    linear-dashboard-sa@tbloom129-dev.iam.gserviceaccount.com
+#            uniqueId 107735894821561716452
+
+issuer: https://accounts.google.com
+subject_pattern: "^(106033804611612894562|107735894821561716452)$"
+
+permissions:
+  # Read open PRs and their requested reviewers. Read-only.
+  pull_requests: read
+
+repositories: []  # Act over all of the repos in the org.


### PR DESCRIPTION
## Summary

Adds an **org-scoped** octo-sts trust policy for the Lens hub (LensReviewQueue data layer). The hub mints a short-lived, **read-only** GitHub token to read pending review requests on open PRs, then flattens them for `/api/review-queue/*`.

- `repositories: []` — one minted token covers every repo in the dashboard's `REVIEW_QUEUE_REPOS` env list, so repos are added via env with **no policy change**. (Same org-wide pattern as `pr-review-audit.sts.yaml`.)
- Federates the preview (jrawlings2) and prod (tbloom129) hub service accounts by Google numeric `uniqueId` — both verified against live IAM.
- Permission scope is `pull_requests: read` only.

Supersedes the repo-level `lens-review-queue.sts.yaml` in `chainguard-dev/mono`, which will be removed once the org scope is verified live.

## Rollout dependency

This policy must merge **before** the hub deploys with the org scope. The hub-side change ([chainguard-dev/mono#44012](https://github.com/chainguard-dev/mono/pull/44012)) pins `OCTO_STS_SCOPE` to repo scope in terraform until this lands, then flips preview → prod.

## Test Plan

- [ ] Merge this policy.
- [ ] Flip `OCTO_STS_SCOPE=chainguard-dev` in Lens preview terraform, apply, confirm `GET /api/review-queue/handles` returns rows (org-scoped mint + GraphQL fetch succeed).
- [ ] Flip prod, confirm handles endpoint returns rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)