### PR TITLE
Add octo-sts trust policies for infosec access-audit GitHub automation

### DIFF
--- a/.github/chainguard/access-audit-github-read.sts.yaml
+++ b/.github/chainguard/access-audit-github-read.sts.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Chainguard, Inc.
+# Copyright 2026 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Read-only token for chainguard-dev/infosec access-audits.yaml: checks out the

--- a/.github/chainguard/access-audit-github-read.sts.yaml
+++ b/.github/chainguard/access-audit-github-read.sts.yaml
@@ -1,0 +1,18 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Read-only token for chainguard-dev/infosec access-audits.yaml: checks out the
+# github-iac member files from infra and lists live chainguard-dev members for the
+# in-PR drift cross-check. Models audit-gh-automation.sts.yaml (members/metadata read).
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/infosec:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/infosec/.github/workflows/access-audits.yaml@refs/heads/main
+
+permissions:
+  contents: read # checkout infra github-iac/orgs/members
+  members: read # GET /orgs/chainguard-dev/members for the drift cross-check
+  metadata: read # read org metadata
+
+repositories:
+  - infra

--- a/.github/chainguard/access-audit-github.sts.yaml
+++ b/.github/chainguard/access-audit-github.sts.yaml
@@ -1,0 +1,18 @@
+# Copyright 2025 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Write token for chainguard-dev/infosec access-audits.yaml to open the GitHub
+# access-audit PR into chainguard-dev/internal. Structurally identical to the
+# deployed sync-gh-users.sts.yaml (which writes PRs into infra/chainguard-devops).
+# A human still reviews/merges every PR; branch protection on internal still applies.
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/infosec:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/infosec/.github/workflows/access-audits.yaml@refs/heads/main
+
+permissions:
+  contents: write # create branch + commit the generated YAML in internal
+  pull_requests: write # open the audit PR
+
+repositories:
+  - internal

--- a/.github/chainguard/access-audit-github.sts.yaml
+++ b/.github/chainguard/access-audit-github.sts.yaml
@@ -1,4 +1,4 @@
-# Copyright 2025 Chainguard, Inc.
+# Copyright 2026 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
 # Write token for chainguard-dev/infosec access-audits.yaml to open the GitHub


### PR DESCRIPTION
## What

Two org-level octo-sts trust policies enabling `chainguard-dev/infosec` `access-audits.yaml` (job `github_audit_pr`) to generate the **GitHub access audit from infra IaC** and open the PR into `chainguard-dev/internal` — replacing the never-shipped GitHub App + Cloud Run path.

- **`access-audit-github-read.sts.yaml`** — `contents/members/metadata: read`, `repositories: [infra]`. Checks out `github-iac/orgs/members` and lists live `chainguard-dev` members for an in-PR drift cross-check. Modeled on `audit-gh-automation.sts.yaml`.
- **`access-audit-github.sts.yaml`** — `contents/pull_requests: write`, `repositories: [internal]`. Opens the audit PR. Structurally identical to the deployed `sync-gh-users.sts.yaml` (which writes PRs into `infra`/`chainguard-devops`).

Both pin `subject: repo:chainguard-dev/infosec:ref:refs/heads/main` and `job_workflow_ref: …/access-audits.yaml@refs/heads/main`.

## Companion PR

chainguard-dev/infosec#765 (the transform + workflow job). **Merge this first** — without these policies the job's token mint fails.

## Owner check

The octo-sts GitHub App installation must include `internal` in its repository selection (it already covers `infra`/`chainguard-devops`). If it's "selected repositories," add `internal`.

⚠️ First automated PR path into `chainguard-dev/internal`; human review/merge of each audit PR is preserved.