### PR TITLE
feat(reviewbot): add prod org STS trust policy

### DIFF
--- a/.github/chainguard/reviewbot.sts.yaml
+++ b/.github/chainguard/reviewbot.sts.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the reviewbot production environment.
+# Service account: reviewbot@prod-enforce-fabc.iam.gserviceaccount.com
+# Subject is the service account uniqueId. PLACEHOLDER until the prod env is
+# applied (env/enforce.dev/iac/400-reviewbot in chainguard-dev/mono); replace
+# with the reviewbot_service_account_unique_id output after the first apply.
+
+issuer: https://accounts.google.com
+subject: "PLACEHOLDER"
+
+permissions:
+  contents: read
+  pull_requests: write
+  checks: write
+  actions: read


### PR DESCRIPTION
## What

Adds the Octo STS trust policy for the **production reviewbot** identity (`reviewbot`).

Reviewbot runs `OrgMain` (org-scoped STS), so its trust policy lives here rather than in the target repo. Permissions mirror `staging-reviewbot` (contents: read, pull_requests: write, checks: write, actions: read)

## Bootstrap ordering

`subject` is a **`PLACEHOLDER`** for now: the prod reviewbot service account (`reviewbot@prod-enforce-fabc.iam.gserviceaccount.com`) doesn't exist until the mono prod env (`env/enforce.dev/iac/400-reviewbot`, #44149) is applied. After that apply, replace `PLACEHOLDER` with the `reviewbot_service_account_unique_id` Terraform output. This is the same two-step bootstrap used for `staging-reviewbot`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
