### PR TITLE
fix(reviewbot): set prod org STS subject to the real SA uniqueId

### DIFF
--- a/.github/chainguard/reviewbot.sts.yaml
+++ b/.github/chainguard/reviewbot.sts.yaml
@@ -3,12 +3,11 @@
 
 # Octo STS policy for the reviewbot production environment.
 # Service account: reviewbot@prod-enforce-fabc.iam.gserviceaccount.com
-# Subject is the service account uniqueId. PLACEHOLDER until the prod env is
-# applied (env/enforce.dev/iac/400-reviewbot in chainguard-dev/mono); replace
-# with the reviewbot_service_account_unique_id output after the first apply.
+# Subject is that service account's uniqueId, seeded from the prod
+# environment apply.
 
 issuer: https://accounts.google.com
-subject: "PLACEHOLDER"
+subject: "104454286738483875255"
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Sets the prod `reviewbot` Octo STS policy `subject` to the real service-account uniqueId, replacing the `PLACEHOLDER` landed in the bootstrap PR now that the prod environment is provisioned.

## Why now

Prod reviewbot is deployed and reconciling, but every GitHub call is denied:

```
trust policy: subject "104454286738483875255" did not match "PLACEHOLDER"
```

So it can't fetch PRs and **no review check runs start** on `ai-review`-labelled PRs. This unblocks that — once merged, prod reviewbot authenticates and begins posting advisory reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
