### PR TITLE
feat(octo-sts): add lens-customer-issues trust policy

### DIFF
--- a/.github/chainguard/lens-customer-issues.sts.yaml
+++ b/.github/chainguard/lens-customer-issues.sts.yaml
@@ -1,0 +1,29 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the Lens hub (customer-issues L3 escalation dashboard).
+# The hub mints a short-lived GitHub token to read customer-issue tickets +
+# comments and to post comments back from Lens, replacing the standing
+# GITHUB_TOKEN that was never set in prod/preview. Same hub Cloud Run service
+# accounts as lens-review-queue (the dashboards share the linear-dashboard svc).
+#
+# Restricted to the single customer-issues repo because this identity carries
+# issues:write — narrower than lens-review-queue's org-wide read, since write is
+# the more dangerous grant.
+#
+# Federates both hub Cloud Run service accounts by their Google numeric uniqueId:
+#   preview: linear-dashboard-sa@jrawlings2-chainguard-dev.iam.gserviceaccount.com
+#            uniqueId 106033804611612894562
+#   prod:    linear-dashboard-sa@tbloom129-dev.iam.gserviceaccount.com
+#            uniqueId 107735894821561716452
+
+issuer: https://accounts.google.com
+subject_pattern: "^(106033804611612894562|107735894821561716452)$"
+
+permissions:
+  # Read customer-issue tickets + comments, and post comments back from Lens.
+  # write implies read, so this one grant covers both the fetch and comment paths.
+  issues: write
+
+repositories:
+  - customer-issues


### PR DESCRIPTION
## Summary

Adds an octo-sts trust policy so the Lens hub can mint a short-lived GitHub token for the **customer-issues L3 escalation dashboard**, replacing a standing `GITHUB_TOKEN`.

Today both GitHub call sites in the hub read `process.env.GITHUB_TOKEN` directly, but that var is intentionally unset in prod/preview — so the GitHub source toggle and the post-to-GitHub comment both `500` in deployed envs. Paired code change: **chainguard-dev/mono#44190** (swaps both call sites to `mintGitHubToken`).

## The grant

- **Federates the two hub Cloud Run SAs** by Google numeric uniqueId — the *same* SAs as `lens-review-queue` (the dashboards share the `linear-dashboard` service). Both verified against the live SAs:
  - preview `linear-dashboard-sa@jrawlings2-chainguard-dev` → `106033804611612894562`
  - prod `linear-dashboard-sa@tbloom129-dev` → `107735894821561716452`
- **`issues: write`**, **restricted to `repositories: [customer-issues]`** — deliberately narrower than `lens-review-queue`'s org-wide read, since write is the more dangerous grant. `write` implies read, so this one permission covers both the fetch and comment paths.

## Ordering

This policy should **merge before** mono#44190 is deployed — until it exists the mint `401`s (no worse than today, where the token is simply absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)