### PR TITLE
image-gen staging: grant issues:write for apk-listener label swap (FUL-426)

### DIFF
--- a/.github/chainguard/staging-image-gen.sts.yaml
+++ b/.github/chainguard/staging-image-gen.sts.yaml
@@ -20,8 +20,9 @@ permissions:
   # Create and update pull requests
   pull_requests: write
 
-  # Read issues (the bot's trigger)
-  issues: read
+  # Read issues (the bot's trigger) + write to swap the pending-apk holding
+  # label to managed (FUL-426 apk-listener)
+  issues: write
 
   # Trigger and manage GitHub Actions workflows
   workflows: write


### PR DESCRIPTION
Grants the **staging** image-gen bot SA `issues: write` so the FUL-426 `apk.push` listener can swap a held issue's holding label to the managed label.

## Why
The listener (chainguard-dev/mono#44449) activates a held stereo issue once its package's APKs publish, by swapping `staging-image-gen/pending-apk` → `staging-image-gen/managed`. That requires `CreateLabel` / `AddLabelsToIssue` / `RemoveLabelForIssue` — all of which need `issues: write`. The policy currently grants only `issues: read` (the bot's reconcile trigger), so the swap would 403.

## Change
```diff
   # Read issues (the bot's trigger)
-  issues: read
+  # Read issues (the bot's trigger) + write to swap the pending-apk holding
+  # label to managed (FUL-426 apk-listener)
+  issues: write
```

No new identity: the listener reuses the existing `image-gen@staging-enforce-cd1e` SA and trust subject, so it inherits this policy. (Trade-off: the listener inherits image-gen's broader SA scope — accepted for a staging PoC.)

The matching dev policy (`dev-mrisharma-image-gen.sts.yaml`) is intentionally **not** bumped: a personal dev broker never receives real `apk.push` events, so the dev write-grant would widen scope with no validation benefit.

Part of [FUL-424](https://linear.app/chainguard/issue/FUL-424) / [FUL-426](https://linear.app/chainguard/issue/FUL-426).