### PR TITLE
feat(octo-sts): grant organization_projects:read to lens-customer-issues policy

### DIFF
--- a/.github/chainguard/lens-customer-issues.sts.yaml
+++ b/.github/chainguard/lens-customer-issues.sts.yaml
@@ -1,39 +1,24 @@
 # Copyright 2026 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Octo STS policy for the Lens hub (customer-issues L3 escalation dashboard).
-# The hub mints a short-lived GitHub token to read customer-issue tickets +
-# comments and to post comments back from Lens, replacing the standing
-# GITHUB_TOKEN that was never set in prod/preview. Same hub Cloud Run service
-# accounts as lens-review-queue (the dashboards share the linear-dashboard svc).
+# Octo STS policy for the Lens dashboard service accounts. Mints a short-lived
+# GitHub token to read issues and an org-level project board and to post issue
+# comments — no standing token.
 #
-# The issues:write grant is restricted to the single customer-issues repo
-# (write is the more dangerous grant). The dashboard's source list also needs
-# org-wide read of Projects v2 (organization_projects: read, below) — read-only
-# and not scopable to one project by GitHub.
+# issues:write is scoped to the single repo below (write is the more dangerous
+# grant). organization_projects:read is org-wide and read-only — GitHub does not
+# allow scoping it to a single project board.
 #
-# Federates both hub Cloud Run service accounts by their Google numeric uniqueId:
-#   preview: linear-dashboard-sa@jrawlings2-chainguard-dev.iam.gserviceaccount.com
-#            uniqueId 106033804611612894562
-#   prod:    linear-dashboard-sa@tbloom129-dev.iam.gserviceaccount.com
-#            uniqueId 107735894821561716452
+# subject_pattern federates the preview + prod service accounts by their Google
+# numeric uniqueId.
 
 issuer: https://accounts.google.com
 subject_pattern: "^(106033804611612894562|107735894821561716452)$"
 
 permissions:
-  # Read customer-issue tickets + comments, and post comments back from Lens.
-  # write implies read, so this one grant covers both the fetch and comment paths.
+  # Read + comment on issues in the repo below (write implies read).
   issues: write
-  # The L3 escalation dashboard now sources its list from the org-level
-  # "Engineering Escalations" Project v2 (#99) via GraphQL
-  # (organization.projectV2(...).items). Reading an org Project v2 requires the
-  # org-level Projects permission — without it the fetch fails and the dashboard
-  # 500s. This is org-wide read of Projects v2 (GitHub doesn't let it be scoped
-  # to a single project number); it's read-only, narrower than write. Issue
-  # *content* for project items still follows issues read above, so items from
-  # repos outside `repositories` surface as project entries with null content
-  # and are skipped client-side until those repos are added here.
+  # Read-only access to org-level project boards (the dashboard's source list).
   organization_projects: read
 
 repositories:

--- a/.github/chainguard/lens-customer-issues.sts.yaml
+++ b/.github/chainguard/lens-customer-issues.sts.yaml
@@ -7,9 +7,10 @@
 # GITHUB_TOKEN that was never set in prod/preview. Same hub Cloud Run service
 # accounts as lens-review-queue (the dashboards share the linear-dashboard svc).
 #
-# Restricted to the single customer-issues repo because this identity carries
-# issues:write — narrower than lens-review-queue's org-wide read, since write is
-# the more dangerous grant.
+# The issues:write grant is restricted to the single customer-issues repo
+# (write is the more dangerous grant). The dashboard's source list also needs
+# org-wide read of Projects v2 (organization_projects: read, below) — read-only
+# and not scopable to one project by GitHub.
 #
 # Federates both hub Cloud Run service accounts by their Google numeric uniqueId:
 #   preview: linear-dashboard-sa@jrawlings2-chainguard-dev.iam.gserviceaccount.com
@@ -24,6 +25,16 @@ permissions:
   # Read customer-issue tickets + comments, and post comments back from Lens.
   # write implies read, so this one grant covers both the fetch and comment paths.
   issues: write
+  # The L3 escalation dashboard now sources its list from the org-level
+  # "Engineering Escalations" Project v2 (#99) via GraphQL
+  # (organization.projectV2(...).items). Reading an org Project v2 requires the
+  # org-level Projects permission — without it the fetch fails and the dashboard
+  # 500s. This is org-wide read of Projects v2 (GitHub doesn't let it be scoped
+  # to a single project number); it's read-only, narrower than write. Issue
+  # *content* for project items still follows issues read above, so items from
+  # repos outside `repositories` surface as project entries with null content
+  # and are skipped client-side until those repos are added here.
+  organization_projects: read
 
 repositories:
   - customer-issues


### PR DESCRIPTION
## What

Add `organization_projects: read` to the `lens-customer-issues` octo-sts trust policy.

## Why

The Lens L3 escalation dashboard ([chainguard-dev/mono#44364](https://github.com/chainguard-dev/mono/pull/44364)) now sources its list from the org-level **Engineering Escalations Project v2 (#99)** via GraphQL (`organization.projectV2(99).items`). Reading an org Project v2 requires the org-level Projects permission — the policy currently grants only `issues: write` on `customer-issues`, so without this the fetch fails and the dashboard 500s (the regression #44364 is meant to fix).

## Scope / safety

- **Read-only**, and narrower than the `issues: write` this identity already carries.
- It is **org-wide** read of Projects v2 — GitHub doesn't allow scoping to a single project number.
- `issues: write` stays restricted to `customer-issues`. Issue *content* for project items still follows the repo-scoped `issues` grant, so items from other repos in #99 come back with null content and are skipped client-side (the dashboard shows the customer-issues escalations). Broadening issue content to more repos would be a separate, deliberate grant.

Federated SAs are unchanged (preview `jrawlings2-chainguard-dev` + prod `tbloom129-dev` hub service accounts).

## Verification

- `yq` parses clean; `permissions` = `{issues: write, organization_projects: read}`.
- Confirms the read half of #44364; once merged, the dashboard fetch against project #99 should return items instead of erroring.
