### PR TITLE
chore(octo-sts): grant issues:write to dev-maxgio-manifest-gen

### DIFF
--- a/.github/chainguard/dev-maxgio-manifest-gen.sts.yaml
+++ b/.github/chainguard/dev-maxgio-manifest-gen.sts.yaml
@@ -20,8 +20,9 @@ permissions:
   # Create and update pull requests
   pull_requests: write
 
-  # Read issues
-  issues: read
+  # Read issue bodies and post reconciliation comments (start comment,
+  # give-up, failure). Matches staging and prod manifest-gen.
+  issues: write
 
   # Trigger and manage GitHub Actions workflows
   workflows: write


### PR DESCRIPTION
Grants `issues: write` to the dev-maxgio manifest-gen reconciler's octo-sts policy.

The dev bot posts comments on the source issue (start comment, give-up, failure). The policy granted `issues: read`, so those POSTs returned 403 and were skipped. Staging and prod manifest-gen already grant `issues: write`; this aligns the dev identity.

The start comment comes from chainguard-dev/mono#44558 (manifest-gen opts into the new metareconciler `WithStartComment` option added in chainguard-dev/mono#44557). This change lets the dev bot post it so #44558 can be verified end-to-end in maxgio-dev.

Verified against the dev deploy in maxgio-dev: the reconciler reached the comment path ("Posting marker comment on #...") and got "insufficient permission" on the POST. This change closes that gap.