### PR TITLE
feat(lens-review-queue): members:read so Team review requests resolve

### DIFF
--- a/.github/chainguard/lens-review-queue.sts.yaml
+++ b/.github/chainguard/lens-review-queue.sts.yaml
@@ -19,5 +19,10 @@ subject_pattern: "^(106033804611612894562|107735894821561716452)$"
 permissions:
   # Read open PRs and their requested reviewers. Read-only.
   pull_requests: read
+  # Read org teams so GraphQL `requestedReviewer { ... on Team }` resolves.
+  # Without this the app token sees Team review requests as null, which
+  # silently drops every team-requested review from the dashboard (the Teams
+  # tab reads empty and team-routed rows lose their attribution). Read-only.
+  members: read
 
 repositories: []  # Act over all of the repos in the org.


### PR DESCRIPTION
GraphQL `requestedReviewer { ... on Team }` nodes resolve as **null** unless the token has the org **Members read** permission, so team review requests are invisible to this token.

+3 lines: `members: read` — read-only, same shape as the existing `pull_requests: read` grant.