### PR TITLE
chore(image-gen): add octoSTS credentials for arthur's image-gen deployment.

### DIFF
--- a/.github/chainguard/dev-aexal15-image-gen.sts.yaml
+++ b/.github/chainguard/dev-aexal15-image-gen.sts.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for image-gen dev environment
+# Service account: aexal15-img@aexal15-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "105552771915277978611"
+
+permissions:
+  # Read github actions logs
+  actions: read
+
+  # Read check status
+  checks: read
+
+  # Create and push branches with the generated image package
+  contents: write
+
+  # Create and update pull requests
+  pull_requests: write
+
+  # Read issues (the bot's trigger)
+  issues: read
+
+  # Trigger and manage GitHub Actions workflows
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
Following image-gen's documentation https://eng.inky.wtf/docs/teams/fulfillment-automation/onboarding/deploy-bot-dev-image-gen/
