### PR TITLE
Add the eng-observability Lens hub SA to the lens policies

### DIFF
--- a/.github/chainguard/lens-customer-issues.sts.yaml
+++ b/.github/chainguard/lens-customer-issues.sts.yaml
@@ -13,7 +13,7 @@
 # numeric uniqueId.
 
 issuer: https://accounts.google.com
-subject_pattern: "^(106033804611612894562|107735894821561716452)$"
+subject_pattern: "^(106033804611612894562|107735894821561716452|116438120363188640248)$"
 
 permissions:
   # Read + comment on issues in the repo below (write implies read).

--- a/.github/chainguard/lens-review-queue.sts.yaml
+++ b/.github/chainguard/lens-review-queue.sts.yaml
@@ -10,11 +10,14 @@
 # Federates both hub Cloud Run service accounts by their Google numeric uniqueId:
 #   preview: linear-dashboard-sa@jrawlings2-chainguard-dev.iam.gserviceaccount.com
 #            uniqueId 106033804611612894562
-#   prod:    linear-dashboard-sa@tbloom129-dev.iam.gserviceaccount.com
+#   prod (legacy, until cutover):
+#            linear-dashboard-sa@tbloom129-dev.iam.gserviceaccount.com
 #            uniqueId 107735894821561716452
+#   prod:    lens-sa@eng-observability.iam.gserviceaccount.com
+#            uniqueId 116438120363188640248
 
 issuer: https://accounts.google.com
-subject_pattern: "^(106033804611612894562|107735894821561716452)$"
+subject_pattern: "^(106033804611612894562|107735894821561716452|116438120363188640248)$"
 
 permissions:
   # Read open PRs and their requested reviewers. Read-only.


### PR DESCRIPTION
The hub also runs as lens-sa@eng-observability (uniqueId 116438120363188640248); it federates like the existing hub SAs, which stay until their environments are retired.