### PR TITLE
add prod-image-gen octosts policy

### DIFF
--- a/.github/chainguard/prod-image-gen.sts.yaml
+++ b/.github/chainguard/prod-image-gen.sts.yaml
@@ -1,0 +1,34 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for image-gen prod environment
+# Service account: image-gen@prod-enforce-fabc.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+# TODO(FUL-521): replace with the SA's numeric unique ID once the prod stage
+# mints it: `terraform output image_gen_stereo_unique_id` in
+# env/enforce.dev/iac/400-image-gen (chainguard-dev/mono#46198).
+subject: "TODO"
+
+permissions:
+  # Read github actions logs
+  actions: read
+
+  # Read check status
+  checks: read
+
+  # Create and push branches with the generated image package
+  contents: write
+
+  # Create and update pull requests
+  pull_requests: write
+
+  # Read issues (the bot's trigger) + write to swap the pending-apk holding
+  # label to managed (FUL-426 apk-listener)
+  issues: write
+
+  # Trigger and manage GitHub Actions workflows
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
Trust policy for the image-gen prod bot SA (`image-gen@prod-enforce-fabc.iam.gserviceaccount.com`), mirroring `staging-image-gen.sts.yaml`. Unblocks the trust-policy verify check on chainguard-dev/mono#46198 (FUL-521).

Draft until the prod stage mints the SA — `subject` is a TODO to be filled from `terraform output image_gen_stereo_unique_id`.