### PR TITLE
fix(grype-db-builder) INT-414: add permissions to parallel osv build

### DIFF
--- a/.github/chainguard/grype-db-builder.sts.yaml
+++ b/.github/chainguard/grype-db-builder.sts.yaml
@@ -8,8 +8,9 @@
 issuer: https://accounts.google.com
 
 # Get with: gcloud iam service-accounts list --project=prod-enforce-fabc --format="table(uniqueId,email)" | grep grypedb
-# grypedb-m4po@prod-enforce-fabc.iam.gserviceaccount.com
-subject: "106629616593211174525"
+# grypedb-m4po@prod-enforce-fabc.iam.gserviceaccount.com (primary) = 106629616593211174525
+# grypedb-ljg9@prod-enforce-fabc.iam.gserviceaccount.com (osv)     = 104116614846982776167
+subject_pattern: "^(106629616593211174525|104116614846982776167)$"
 
 permissions:
   contents: read

--- a/.github/chainguard/staging-grype-db-builder.sts.yaml
+++ b/.github/chainguard/staging-grype-db-builder.sts.yaml
@@ -8,8 +8,9 @@
 issuer: https://accounts.google.com
 
 # Get with: gcloud iam service-accounts list --project=staging-enforce-cd1e --format="table(uniqueId,email)" | grep grypedb
-# grypedb-wri5@staging-enforce-cd1e.iam.gserviceaccount.com
-subject: "106459491698429179709"
+# grypedb-wri5@staging-enforce-cd1e.iam.gserviceaccount.com (primary) = 106459491698429179709
+# grypedb-8yiq@staging-enforce-cd1e.iam.gserviceaccount.com (osv)     = 104538207444205632939
+subject_pattern: "^(106459491698429179709|104538207444205632939)$"
 
 permissions:
   contents: read


### PR DESCRIPTION
### What

Add another valid account / subject to the octo-sts check for grype-db-builder

### Why

To validate our OSV grype changes, we want parallel builds of grype DBs using SecDB and OSV. This is currently failing in part because OSV build lacks permissions based on this file. 