### PR TITLE
Add doc-approval jrawlings2 dev identity

### DIFF
--- a/.github/chainguard/dev-jrawlings-doc-approval.sts.yaml
+++ b/.github/chainguard/dev-jrawlings-doc-approval.sts.yaml
@@ -1,0 +1,14 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the doc-approval jrawlings2 dev environment.
+# Service account: doc-approval@jrawlings2-chainguard-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "103721174803380423559"
+
+permissions:
+  contents: read
+  pull_requests: read
+  checks: write
+  members: read


### PR DESCRIPTION
Dev-environment identity for the doc-approval reconciler. Models dev-jrawlings-reviewbot; members:read models audit-gh-automation.