### PR TITLE
Add doc-approval staging and prod identities (placeholder subjects)

### DIFF
--- a/.github/chainguard/doc-approval-bot.sts.yaml
+++ b/.github/chainguard/doc-approval-bot.sts.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the doc-approval production environment.
+# Service account: doc-approval@prod-enforce-fabc.iam.gserviceaccount.com
+# Subject is the service account uniqueId; placeholder until provisioned.
+#
+# TODO(post-apply): replace the PLACEHOLDER below with the uniqueId.
+
+issuer: https://accounts.google.com
+subject: "PLACEHOLDER_REPLACE_WITH_PROD_SA_UNIQUE_ID"
+
+permissions:
+  contents: read
+  pull_requests: read
+  checks: write
+  members: read

--- a/.github/chainguard/staging-doc-approval.sts.yaml
+++ b/.github/chainguard/staging-doc-approval.sts.yaml
@@ -1,0 +1,17 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the doc-approval staging environment.
+# Service account: doc-approval@staging-enforce-cd1e.iam.gserviceaccount.com
+# Subject is the service account uniqueId; placeholder until provisioned.
+#
+# TODO(post-apply): replace the PLACEHOLDER below with the uniqueId.
+
+issuer: https://accounts.google.com
+subject: "PLACEHOLDER_REPLACE_WITH_STAGING_SA_UNIQUE_ID"
+
+permissions:
+  contents: read
+  pull_requests: read
+  checks: write
+  members: read


### PR DESCRIPTION
Staging and production identities for the doc-approval reconciler, with placeholder subjects until the environments are provisioned (same pattern as staging-reviewbot). Placeholder subjects match no principal, so these grant nothing until seeded with real uniqueIds post-apply. Models dev-jrawlings-doc-approval / audit-gh-automation for the members:read scope.