### PR TITLE
Seed doc-approval staging identity with the provisioned uniqueId

### DIFF
--- a/.github/chainguard/staging-doc-approval.sts.yaml
+++ b/.github/chainguard/staging-doc-approval.sts.yaml
@@ -3,12 +3,10 @@
 
 # Octo STS policy for the doc-approval staging environment.
 # Service account: doc-approval@staging-enforce-cd1e.iam.gserviceaccount.com
-# Subject is the service account uniqueId; placeholder until provisioned.
-#
-# TODO(post-apply): replace the PLACEHOLDER below with the uniqueId.
+# Subject is the service account uniqueId.
 
 issuer: https://accounts.google.com
-subject: "PLACEHOLDER_REPLACE_WITH_STAGING_SA_UNIQUE_ID"
+subject: "105635533974378397456"
 
 permissions:
   contents: read


### PR DESCRIPTION
Replaces the placeholder subject with the uniqueId of doc-approval@staging-enforce-cd1e (provisioned by chainguard-dev/mono#47533). Same scopes as reviewed in #275.