### PR TITLE
feat: OctoSTS policy for dev-yashp-cg image-gen bot SA

### DIFF
--- a/.github/chainguard/dev-yashp-cg-image-gen.sts.yaml
+++ b/.github/chainguard/dev-yashp-cg-image-gen.sts.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for image-gen dev environment
+# Service account: yashp-cg-img@yashp-cg-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "107860992120501566914"
+
+permissions:
+  # Read github actions logs
+  actions: read
+
+  # Read check status
+  checks: read
+
+  # Create and push branches with the generated image package
+  contents: write
+
+  # Create and update pull requests
+  pull_requests: write
+
+  # Read issues (the bot's trigger)
+  issues: read
+
+  # Trigger and manage GitHub Actions workflows
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
## Summary
Adds the OctoSTS trust policy for the `dev-yashp-cg-image-gen` identity — the deployed image-gen bot in the `yashp-cg` dev environment (project `yashp-cg-dev`).

- **Subject**: `107860992120501566914` — the bot's runtime service account `yashp-cg-img@yashp-cg-dev.iam.gserviceaccount.com` (verified via `gcloud iam service-accounts list` and the 400-image-gen `service_account_unique_id` terraform output)
- **Issuer**: `https://accounts.google.com` (GCP SA), scoped to the `stereo` repository only
- Mirrors `dev-aexal15-image-gen.sts.yaml` / `dev-jcamisso-image-gen.sts.yaml` (prior art: #217)

## Why
Companion to chainguard-dev/mono#47698 (env/dev/yashp-cg dev environment provisioning). mono's `octosts-lint` check requires this policy to exist before the `400-image-gen` stage referencing the identity can merge.