### PR TITLE
feat: octo-sts policy for alert-slack-bot review queue

### DIFF
--- a/.github/chainguard/alert-slack-bot.sts.yaml
+++ b/.github/chainguard/alert-slack-bot.sts.yaml
@@ -1,19 +1,16 @@
 # Copyright 2026 Chainguard, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Read-only token for the alert-slack-bot review-queue policy
-# (chainguard-dev/mono#47496): team membership lookup plus PR search.
-# Org-level because members:read is an org permission; repo access is
-# limited to mono. Models approver-bot (Google-issuer SA federation)
-# and access-audit-github-read (members read).
+# Read-only access for the alert-slack-bot review-queue policy: team
+# membership lookup plus PR search, limited to mono.
 issuer: https://accounts.google.com
 
 # alert-slack-bot@staging-enforce-cd1e | alert-slack-bot@prod-enforce-fabc
 subject_pattern: (114816490335454510913|115816735061299852605)
 
 permissions:
-  members: read       # resolve the policy's author_team membership
-  pull_requests: read # PR search and review data
+  members: read
+  pull_requests: read
   metadata: read
 
 repositories:

--- a/.github/chainguard/alert-slack-bot.sts.yaml
+++ b/.github/chainguard/alert-slack-bot.sts.yaml
@@ -1,0 +1,20 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Read-only token for the alert-slack-bot review-queue policy
+# (chainguard-dev/mono#47496): team membership lookup plus PR search.
+# Org-level because members:read is an org permission; repo access is
+# limited to mono. Models approver-bot (Google-issuer SA federation)
+# and access-audit-github-read (members read).
+issuer: https://accounts.google.com
+
+# alert-slack-bot@staging-enforce-cd1e | alert-slack-bot@prod-enforce-fabc
+subject_pattern: (114816490335454510913|115816735061299852605)
+
+permissions:
+  members: read       # resolve the policy's author_team membership
+  pull_requests: read # PR search and review data
+  metadata: read
+
+repositories:
+  - mono


### PR DESCRIPTION
Ref AUTO-920

The alert-slack-bot gains a GitHub review-queue policy source in chainguard-dev/mono#47496 but has no GitHub access today. This grants its staging and prod service accounts a read-only token: members read for the team lookup, pull requests read limited to mono. Same shape as approver-bot and access-audit-github-read.