### PR TITLE
feat(octosts): trust policy for the doc-driven review approver (placeholder subject)

### DIFF
--- a/.github/chainguard/approver-doc-driven.sts.yaml
+++ b/.github/chainguard/approver-doc-driven.sts.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the approver-doc-driven identity (production).
+# Service account: approver-doc-driven@prod-enforce-fabc.iam.gserviceaccount.com
+# Subject is the service account's uniqueId, seeded after the environment's
+# first apply; the placeholder below matches no token until then.
+issuer: https://accounts.google.com
+subject: "000000000000000000000"
+
+permissions:
+  contents: read
+  checks: read
+  statuses: read
+  pull_requests: write
+
+repositories:
+- mono


### PR DESCRIPTION
Adds the octo-sts trust policy for the `approver-doc-driven` identity so it resolves.

**Placeholder subject.** The service account doesn't exist until the environment's first apply, so the subject is a placeholder that matches no token (inert) until it's seeded from the service account's uniqueId afterwards.

Least-privilege: `contents: read` (no write), `checks: read`, `statuses: read`, `pull_requests: write`, scoped to `mono`.