### PR TITLE
feat(octosts): grant issues:write to dev-wimpress-manifest-gen

### DIFF
--- a/.github/chainguard/dev-wimpress-manifest-gen.sts.yaml
+++ b/.github/chainguard/dev-wimpress-manifest-gen.sts.yaml
@@ -13,7 +13,8 @@ permissions:
   checks: read
   contents: write
   pull_requests: write
-  issues: read
+  # Read issues to fetch issue body; post failure comments and apply the halt label on issues
+  issues: write
   workflows: write
 
 repositories:


### PR DESCRIPTION
Grants `issues: write` to `dev-wimpress-manifest-gen`, so the bot can post failure comments and apply its halt label.

Matches `dev-cbutler-manifest-gen`, `dev-jcamisso-manifest-gen`, `dev-klrmngr-manifest-gen`, `staging-manifest-gen` and `prod-manifest-gen`. Same change as #263 did for `dev-zkranurag-image-gen`.

## Why

With `issues: read` the bot's two issue writes both 403:

- `Issues.CreateComment` in `bots/manifest-gen/pkg/reconciler/failure.go:572`, so a terminal failure is never surfaced on the issue.
- `AddLabelsToIssue` for the `skip:dev-wimpress-manifest-gen` halt label in `failure.go:595`.

The halt failure is not self-healing. `retryLabelWrite` abandons a 403 or 404 after one attempt (`failure.go:619-621`), so the label never lands. Six failure classes are durable (`failure.go:216-227`): `empty-result`, `generation-blocked`, `missing-test-section`, `unresolved-commit`, `no-component` and `destructive-edit`. Each such issue re-runs a full agent pass, up to the 45 minute generation timeout, on every subsequent stereo event, with no visible reason on the issue.

Observed on a live run against stereo issue 170005:

```
could not halt reconciliation (grant issues:write); issue may be reprocessed on future events
Skipping marker comment: insufficient permission
```

## Scope

This is the org-level policy used by the deployed Cloud Run bot. The matching per-repo policy for local runs is a separate PR in `chainguard-dev/stereo`.
