### PR TITLE
feat(octosts): add dev-wimpress-image-gen policy

### DIFF
--- a/.github/chainguard/dev-wimpress-image-gen.sts.yaml
+++ b/.github/chainguard/dev-wimpress-image-gen.sts.yaml
@@ -1,0 +1,31 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for image-gen dev environment
+# Service account: wimpress-img@wimpress-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "116516312068509403099"
+
+permissions:
+  # Read github actions logs
+  actions: read
+
+  # Read check status
+  checks: read
+
+  # Create and push branches with the generated image package
+  contents: write
+
+  # Create and update pull requests
+  pull_requests: write
+
+  # Read issue bodies (the bot's trigger), and comment on / label issues to
+  # surface terminal failures and apply the skip:<identity> halt label.
+  issues: write
+
+  # Trigger and manage GitHub Actions workflows
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
Trust policy for the deployed image-gen dev bot at `wimpress-img@wimpress-dev.iam.gserviceaccount.com`, subject `116516312068509403099`. Supports the new stage in chainguard-dev/mono#48566, which is applied and running.

Mirrors `dev-zkranurag-image-gen`, scoped to `stereo`.

## Why `issues: write` from the start

With `issues: read` the bot cannot post failure comments (`bots/manifest-gen/pkg/reconciler/failure.go:572` in mono) or apply its `skip:<identity>` halt label (`failure.go:595`). The halt failure does not recover: `retryLabelWrite` abandons a 403 after one attempt (`failure.go:619-621`), so the label never lands and a durably failing issue re-runs a full agent pass on every subsequent event.

I hit exactly that on my manifest-gen bot today, fixed in #282. Starting image-gen with the right permission rather than repeating it.

## Scope

This is the org-level policy the deployed Cloud Run bot resolves. The per-repo policy for local runs is chainguard-dev/stereo#200102.
