### PR TITLE
feat: add maxgio autofixer Octo STS policies

### DIFF
--- a/.github/chainguard/dev-maxgio-eco-java-autofixer-skills.sts.yaml
+++ b/.github/chainguard/dev-maxgio-eco-java-autofixer-skills.sts.yaml
@@ -1,0 +1,14 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Read-only Java repair skills for the maxgio-dev dev autofixer.
+# Service account: eco-java-autofixer@maxgio-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "102194038154041610217"
+
+permissions:
+  contents: read
+
+repositories:
+  - ecosystems-java-rebuilder

--- a/.github/chainguard/dev-maxgio-eco-java-autofixer.sts.yaml
+++ b/.github/chainguard/dev-maxgio-eco-java-autofixer.sts.yaml
@@ -1,0 +1,19 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the maxgio-dev Eco Java Autofixer dev environment.
+# Service accounts:
+# - eco-java-autofixer@maxgio-dev.iam.gserviceaccount.com
+# - eco-java-autofixer-ghe@maxgio-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject_pattern: "(102194038154041610217|100655627982885661774)"
+
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  pull_requests: write
+
+repositories:
+  - ecosystems-packages


### PR DESCRIPTION
## Summary

Add Octo STS policies for the maxgio-dev Eco Java Autofixer dev environment, mirroring the klrmngr set.

- `dev-maxgio-eco-java-autofixer`: the reconciler and GitHub-events enqueuer read `actions`/`checks` and write `contents`/`pull_requests` on `ecosystems-packages`, to open and reconcile managed rebuild PRs.
- `dev-maxgio-eco-java-autofixer-skills`: the reconciler reads `ecosystems-java-rebuilder` for the Java repair skills.

Subjects are the numeric IDs of the maxgio-dev bootstrap service accounts (`eco-java-autofixer@` reconciler and `eco-java-autofixer-ghe@` GitHub-events enqueuer), created by the `400-eco-java-autofixer` bootstrap apply.
