### PR TITLE
chore(sts): grant approver-doc-driven contents:write

### DIFF
--- a/.github/chainguard/approver-doc-driven.sts.yaml
+++ b/.github/chainguard/approver-doc-driven.sts.yaml
@@ -9,7 +9,9 @@ issuer: https://accounts.google.com
 subject: "000000000000000000000"
 
 permissions:
-  contents: read
+  # write (not read): this identity writes merge commits to the protected
+  # branch, so read is insufficient.
+  contents: write
   checks: read
   statuses: read
   pull_requests: write


### PR DESCRIPTION
⛔ **Draft / do not merge until the subject is filled in.**

The `approver-doc-driven` identity writes merge commits to the target repo's protected branch, so it needs `contents: write` (was `read`).

Two things gate merging this:
1. `contents: read` → `write` (this change).
2. `subject` is still the placeholder `000…`; it is seeded from the service account's uniqueId after the environment's first apply. That value must be filled in before merge, or the identity mints no tokens.