### PR TITLE
chore(sts): add a trust policy for the cbutler image-gen dev bot

### DIFF
--- a/.github/chainguard/dev-cbutler-image-gen.sts.yaml
+++ b/.github/chainguard/dev-cbutler-image-gen.sts.yaml
@@ -1,0 +1,31 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for image-gen dev environment
+# Service account: cbutler-img@cbutler-dev.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "108317626125660864341"
+
+permissions:
+  # Read github actions logs
+  actions: read
+
+  # Read check status
+  checks: read
+
+  # Create and push branches with the generated image package
+  contents: write
+
+  # Create and update pull requests
+  pull_requests: write
+
+  # Read issue bodies (the bot's trigger), and comment on / label issues to
+  # surface terminal failures and apply the skip:<identity> halt label.
+  issues: write
+
+  # Trigger and manage GitHub Actions workflows
+  workflows: write
+
+repositories:
+  - stereo


### PR DESCRIPTION
Lets `cbutler-img@cbutler-dev` assume `dev-cbutler-image-gen` against `stereo`. The service account is created by `env/dev/cbutler/400-image-gen` in mono (chainguard-dev/mono#49870); `subject` is its uniqueId.

Permissions mirror `dev-wimpress-image-gen`. `issues` is `write` rather than `read` because image-gen comments on the originating issue and applies the `skip:<identity>` halt label when a run terminates, for example on an unpublished main APK.

Scoped to `stereo`, which is both the source of the bot's trigger issues and the target for its PRs.