### PR TITLE
fix(aexal15): wrong GCP account for arthur.exaltacao image-gen dev environment

### DIFF
--- a/.github/chainguard/dev-aexal15-image-gen.sts.yaml
+++ b/.github/chainguard/dev-aexal15-image-gen.sts.yaml
@@ -5,7 +5,7 @@
 # Service account: aexal15-img@aexal15-dev.iam.gserviceaccount.com
 
 issuer: https://accounts.google.com
-subject: "105552771915277978611"
+subject: "106944339722616318248"
 
 permissions:
   # Read github actions logs


### PR DESCRIPTION
Seems that my development environment has been failing with this issue:

```
Reconciliation failed for key https://github.com/chainguard-dev/stereo/issues/228033: fetch issue: Get "https://api.github.com/repos/chainguard-dev/stereo/issues/228033": rpc error: code = PermissionDenied desc = trust policy: subject "102436943639830841492" did not match "105552771915277978611"
```

I thought this was due to my bot not having created the latest PR but I believe I've set the account incorrectly.