### PR TITLE
feat(octo-sts): reviewbot trust policy for tcnghia.net dev env

### DIFF
--- a/.github/chainguard/dev-tcnghia-reviewbot.sts.yaml
+++ b/.github/chainguard/dev-tcnghia-reviewbot.sts.yaml
@@ -1,0 +1,14 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the reviewbot tcnghia.net dev environment.
+# Service account: reviewbot@nghia-chainguard-ng.iam.gserviceaccount.com
+
+issuer: https://accounts.google.com
+subject: "115641465214975960824"
+
+permissions:
+  contents: read
+  pull_requests: write
+  checks: write
+  actions: read


### PR DESCRIPTION
Adds the octo-sts trust policy for the `reviewbot` reconciler in the `tcnghia.net` dev env. The subject is the reconciler service account's uniqueId (`reviewbot@nghia-chainguard-ng`); it grants `contents: read`, `pull_requests: write`, `checks: write`, and `actions: read` for COMMENT-only advisory review.

The reconciler authenticates with an **org-scoped** octo-sts token: the DAF github reconciler entrypoint calls [`NewOrgTokenSource(ctx, identity, org)`](https://github.com/chainguard-dev/mono/blob/e22cd6cddd6005f0d63a73a50bfa223759cbed1a/public/go-driftlessaf/reconcilers/githubreconciler/entrypoint.go#L158), which exchanges with an empty repo ([`NewTokenSourceFromValues(ctx, identity, org, "")`](https://github.com/chainguard-dev/mono/blob/e22cd6cddd6005f0d63a73a50bfa223759cbed1a/public/go-driftlessaf/reconcilers/githubreconciler/tokensource.go#L61-L62)). Org-scoped tokens resolve their trust policy from this org `.github` repo, not from a per-repo `.github/chainguard/`. The policy was initially placed in `chainguard-dev/mono/.github/chainguard/` by mistake; that per-repo location is never consulted for an org-scoped exchange, so octo-sts returned `NotFound` for `dev-tcnghia-reviewbot`. The misplaced file is removed in a follow-up.

Companion to the dev-env deployment in chainguard-dev/mono#50549.