### PR TITLE
feat(octo-sts): approver trust policy for tcnghia.net dev env

### DIFF
--- a/.github/chainguard/dev-tcnghia-approver-bot.sts.yaml
+++ b/.github/chainguard/dev-tcnghia-approver-bot.sts.yaml
@@ -1,0 +1,22 @@
+# Copyright 2026 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+# Octo STS policy for the approver tcnghia.net dev environment.
+# Service account: approver@nghia-chainguard-ng.iam.gserviceaccount.com
+#
+# Approve-only: the bot submits an approving review and labels PRs, but never
+# merges, so it needs no contents: write (staging-approver-bot has it only for
+# its direct-merge path). Deployed by env/dev/tcnghia.net/iac/999-approver in
+# chainguard-dev/mono; scoped to mono, the only repo it approves.
+
+issuer: https://accounts.google.com
+subject: "108253857776007391606"
+
+permissions:
+  contents: read
+  checks: read
+  statuses: read
+  pull_requests: write
+
+repositories:
+- mono


### PR DESCRIPTION
Adds the octo-sts trust policy for the doc-driven **approver** deployed to the `tcnghia.net` dev env (`env/dev/tcnghia.net/iac/999-approver` in chainguard-dev/mono).

Sibling to the reviewbot policy (#291). The approver reads the reviewbot's `doc-alignment` check verdict and, when the doc-driven gates pass, submits an **approving review** on mono PRs. Approve-only — it never merges.

- **Subject**: `108253857776007391606` (uniqueId of `approver@nghia-chainguard-ng.iam.gserviceaccount.com`).
- **Permissions**: `pull_requests: write` (submit review + label), plus read-only `contents`/`checks`/`statuses`. No `contents: write` since it does not merge (staging-approver-bot carries that only for its direct-merge path).
- **Scope**: `mono` only.